### PR TITLE
feat: simplified gift cards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = monorepo(__dirname);
 
 module.exports.overrides.push(
   {
-    files: ['playgrounds/**/*.ts', 'end-to-end/**/*.ts', '**/cli.ts', 'cli/*'],
+    files: ['playgrounds/**/*.ts', 'end-to-end/**/*.ts', '**/cli.ts', '**/cli/*'],
     rules: {
       'no-console': 'off',
     },

--- a/apps/chromealive-core/index.ts
+++ b/apps/chromealive-core/index.ts
@@ -183,7 +183,6 @@ export default class ChromeAliveCore {
     const minerAddress = await this.minerAddress;
     heroSession.bypassResourceRegistrationForHost = new URL(minerAddress);
 
-
     this.sessionObserversById.set(sessionId, sessionObserver);
     const sourceCode = sessionObserver.sourceCodeTimeline;
     const timetravel = sessionObserver.timetravelPlayer;
@@ -361,6 +360,12 @@ export default class ChromeAliveCore {
     if (!event.browser.engine.isHeaded) return;
 
     const browserId = event.browser.id;
+
+    const hasSessionObservers = HeroSession.sessionsWithBrowserId(browserId).some(x =>
+      this.sessionObserversById.has(x.id),
+    );
+    if (!hasSessionObservers) return;
+
     const restartedSessionId = this.restartingHeroSessionId;
     const checkForBrowserClose = (): any => {
       if (

--- a/databox/client/cli/giftCardCommands.ts
+++ b/databox/client/cli/giftCardCommands.ts
@@ -1,0 +1,118 @@
+import { Command } from 'commander';
+import * as Path from 'path';
+import { getCacheDirectory } from '@ulixee/commons/lib/dirUtils';
+import Identity from '@ulixee/crypto/lib/Identity';
+import * as Fs from 'fs';
+import { sidechainHostOption } from '@ulixee/sidechain/cli/common';
+import IDataboxManifest from '@ulixee/specification/types/IDataboxManifest';
+import { readFileAsJson } from '@ulixee/commons/lib/fileUtils';
+import { createGiftCard } from '@ulixee/sidechain/cli/giftCardsCli';
+
+export default function giftCardCommands(): Command {
+  const giftCardIssuersDir = Path.join(getCacheDirectory(), 'ulixee', 'gift-card-issuers');
+
+  const cli = new Command('gift-cards');
+  cli
+    .command('create')
+    .description('Create a gift card for a databox.')
+    .argument('<path>', 'The path of the entrypoint to the databox.')
+    .addOption(sidechainHostOption)
+    .requiredOption(
+      '-m, --amount <value>',
+      'The value of this gift card. Amount can postfix "c" for centagons (eg, 50c) or "m" for microgons (5000000m).',
+      /\d+[mc]?/,
+    )
+    .option('-i, --identity <idBech32String>', 'Use an existing gift card issuer.')
+    .option(
+      '-m, --miner-db-host <host>',
+      'Your miner host ip and port accepting postgres connections',
+    )
+    .action(async (path, { identity, amount, host, minerDbHost }) => {
+      let manifest: Partial<IDataboxManifest> = {};
+      const specifiedIdentity = !!identity;
+      const manifestPath = Path.resolve(path).replace(Path.extname(path), '-manifest.json');
+      if (Fs.existsSync(manifestPath)) {
+        manifest = (await readFileAsJson<IDataboxManifest>(manifestPath)) ?? {};
+        identity = manifest.giftCardIssuerIdentity;
+      }
+
+      let signer: Identity;
+      if (identity) {
+        signer = Identity.loadFromFile(Path.join(giftCardIssuersDir, `${identity}.pem`));
+        if (!signer && specifiedIdentity)
+          throw new Error(
+            `The gift card issuer you requested could not be found locally (${Path.join(
+              giftCardIssuersDir,
+              `${identity}.pem`,
+            )}).`,
+          );
+        else if (!signer)
+          throw new Error(
+            `The gift card issuer for this Databox could not be found in the gift card issuers directory (${Path.join(
+              giftCardIssuersDir,
+              `${identity}.pem`,
+            )}).`,
+          );
+      }
+
+      if (!signer) {
+        signer = await Identity.create();
+        await signer.save(Path.join(giftCardIssuersDir, `${signer.bech32}.pem`));
+      }
+
+      if (manifest.giftCardIssuerIdentity !== signer.bech32) {
+        manifest.giftCardIssuerIdentity = signer.bech32;
+        await Fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+        console.log(`
+
+!! You must re-upload your Databox for gift cards to take effect. !!
+        
+`);
+      }
+
+      const giftCard = await createGiftCard({
+        amount,
+        identityPath: Path.join(giftCardIssuersDir, `${signer.bech32}.pem`),
+        host,
+      });
+
+      if (minerDbHost) {
+        console.log(`Or they can try out your databox over a PostgreSQL connection:
+"postgres://${giftCard.giftCardId}:${giftCard.redemptionKey}@${minerDbHost}"
+`);
+      }
+    });
+
+  cli
+    .command('create-issuer')
+    .description('Create an issuer identity')
+    .action(async () => {
+      const issuer = await Identity.create();
+      await issuer.save(Path.join(giftCardIssuersDir, `${issuer.bech32}..pem`));
+      console.log(
+        'Gift card issuer created at %s.',
+        Path.join(giftCardIssuersDir, `${issuer.bech32}.pem`),
+      );
+    });
+
+  cli
+    .command('list-issuers')
+    .description('List installed issuer identities')
+    .action(async () => {
+      let keys: string[] = [];
+      if (!Fs.existsSync(giftCardIssuersDir)) {
+        keys = await Fs.promises.readdir(giftCardIssuersDir);
+        keys = keys.filter(x => x.endsWith('..pem')).map(x => x.replace('.pem', ''));
+      }
+      if (!keys.length) {
+        console.log(
+          'You have no installed gift card issuers. They would be installed here if you had any: %s',
+          giftCardIssuersDir,
+        );
+        return;
+      }
+
+      console.log('You have the following gift card issuers installed %s.', keys.toString());
+    });
+  return cli;
+}

--- a/databox/client/package.json
+++ b/databox/client/package.json
@@ -20,6 +20,7 @@
     "@ulixee/crypto": "2.0.0-alpha.14",
     "@ulixee/databox-interfaces": "2.0.0-alpha.14",
     "@ulixee/net": "2.0.0-alpha.14",
+    "@ulixee/sidechain": "2.0.0-alpha.14",
     "@ulixee/schema": "2.0.0-alpha.14",
     "@ulixee/specification": "2.0.0-alpha.14",
     "commander": "^9.3.0",

--- a/databox/core/.env.defaults
+++ b/databox/core/.env.defaults
@@ -3,13 +3,16 @@ ULX_DATABOX_DIR=<CACHE>/ulixee/databoxes
 ULX_DBX_UPLOADER_IDENTITIES=
 # Payment Address of this Miner owner to pay out databox revenue (bech32 string)
 ULX_PAYMENT_ADDRESS=
-# Payment Address of this Miner (if any) accepting gift card payments (bech32 string)
-ULX_GIFT_CARD_ADDRESS=
+# If gift cards are allowed on this Miner. If you wish to restrict usage, use ULX_GIFT_CARD_ISSUER_IDENTITY
+ULX_GIFT_CARDS_ALLOWED=true
+# Gift Card Issuer Identity of this Miner if it must authorize Databox gift cards (bech32 string)
+ULX_GIFT_CARDS_REQUIRED_ISSUER_IDENTITY=
+
 # Price add-on per KB (microgons). This is on top of regular pricing and is mostly used for surge pricing when there is competition for hosting.
-ULX_PRICE_PER_KB=
+ULX_PRICE_PER_KB=0
 # Default sidechain host
 ULX_SIDECHAIN_HOST=https://payments.ulixee.org
-# Pinned default sidechain identity. TODO: fill in once sidechain launches
+# Pinned default sidechain identity. TODO: fill in once sidechain is up
 ULX_SIDECHAIN_IDENTITY=
 
 ## Miner Identity (PKI) with Sidechain (NOTE: use cloud hosted secrets if available!!)

--- a/databox/core/endpoints/Databox.meta.ts
+++ b/databox/core/endpoints/Databox.meta.ts
@@ -5,19 +5,24 @@ export default new DataboxApiHandler('Databox.meta', {
   async handler(request, context) {
     await DataboxCore.start();
 
-    const databox = context.databoxRegistry.getByVersionHash(request.versionHash);
-    const giftCardPaymentAddresses: string[] = [];
+    const { giftCardsRequiredIssuerIdentity, giftCardsAllowed, computePricePerKb } =
+      context.configuration;
 
-    if (context.configuration.giftCardAddress && databox.giftCardAddress) {
-      giftCardPaymentAddresses.push(databox.giftCardAddress);
-      if (context.configuration.giftCardAddress !== databox.giftCardAddress) {
-        giftCardPaymentAddresses.push(context.configuration.giftCardAddress);
+    const databox = context.databoxRegistry.getByVersionHash(request.versionHash);
+    const giftCardIssuerIdentities: string[] = [];
+    if ((giftCardsRequiredIssuerIdentity || giftCardsAllowed) && databox.giftCardIssuerIdentity) {
+      giftCardIssuerIdentities.push(databox.giftCardIssuerIdentity);
+      if (
+        giftCardsRequiredIssuerIdentity &&
+        giftCardsRequiredIssuerIdentity !== databox.giftCardIssuerIdentity
+      ) {
+        giftCardIssuerIdentities.push(giftCardsRequiredIssuerIdentity);
       }
     }
 
     return {
       latestVersionHash: databox.latestVersionHash,
-      giftCardPaymentAddresses,
+      giftCardIssuerIdentities,
       averageMilliseconds: databox.stats.averageMilliseconds,
       maxMilliseconds: databox.stats.maxMilliseconds,
       averageTotalPricePerQuery: databox.stats.averagePrice,
@@ -25,7 +30,7 @@ export default new DataboxApiHandler('Databox.meta', {
       averageBytesPerQuery: databox.stats.averageBytes,
       maxBytesPerQuery: databox.stats.maxBytes,
       basePricePerQuery: databox.pricePerQuery,
-      computePricePerKb: context.configuration.computePricePerKb,
+      computePricePerKb,
       schemaInterface: databox.schemaInterface,
     };
   },

--- a/databox/core/lib/DataboxManifest.ts
+++ b/databox/core/lib/DataboxManifest.ts
@@ -31,7 +31,7 @@ export default class DataboxManifest implements IDataboxManifest {
   // Payment details
   public pricePerQuery?: number;
   public paymentAddress?: string;
-  public giftCardAddress?: string;
+  public giftCardIssuerIdentity?: string;
 
   public linkedVersions: IVersionHistoryEntry[];
   public allVersions: IVersionHistoryEntry[];
@@ -183,7 +183,7 @@ export default class DataboxManifest implements IDataboxManifest {
       coreVersion: this.coreVersion,
       corePlugins: this.corePlugins,
       paymentAddress: this.paymentAddress,
-      giftCardAddress: this.giftCardAddress,
+      giftCardIssuerIdentity: this.giftCardIssuerIdentity,
       pricePerQuery: this.pricePerQuery,
       schemaInterface: this.schemaInterface,
     };
@@ -259,7 +259,7 @@ export default class DataboxManifest implements IDataboxManifest {
       | 'scriptEntrypoint'
       | 'linkedVersions'
       | 'paymentAddress'
-      | 'giftCardAddress'
+      | 'giftCardIssuerIdentity'
       | 'pricePerQuery'
     >,
   ): string {
@@ -269,7 +269,7 @@ export default class DataboxManifest implements IDataboxManifest {
       scriptEntrypoint,
       pricePerQuery,
       paymentAddress,
-      giftCardAddress,
+      giftCardIssuerIdentity,
       linkedVersions,
     } = manifest;
     linkedVersions.sort((a, b) => b.versionTimestamp - a.versionTimestamp);
@@ -279,7 +279,7 @@ export default class DataboxManifest implements IDataboxManifest {
       scriptEntrypoint,
       pricePerQuery,
       paymentAddress,
-      giftCardAddress,
+      giftCardIssuerIdentity,
       JSON.stringify(linkedVersions),
     );
     const sha = HashUtils.sha3(hashMessage);

--- a/databox/core/lib/DataboxesTable.ts
+++ b/databox/core/lib/DataboxesTable.ts
@@ -15,7 +15,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
         ['versionHash', 'TEXT', 'NOT NULL PRIMARY KEY'],
         ['versionTimestamp', 'DATETIME'],
         ['paymentAddress', 'TEXT'],
-        ['giftCardAddress', 'TEXT'],
+        ['giftCardIssuerIdentity', 'TEXT'],
         ['pricePerQuery', 'INTEGER'],
         ['scriptHash', 'TEXT'],
         ['scriptEntrypoint', 'TEXT'],
@@ -36,7 +36,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
       manifest.versionHash,
       manifest.versionTimestamp,
       manifest.paymentAddress,
-      manifest.giftCardAddress,
+      manifest.giftCardIssuerIdentity,
       manifest.pricePerQuery,
       manifest.scriptHash,
       manifest.scriptEntrypoint,
@@ -50,7 +50,7 @@ export default class DataboxesTable extends SqliteTable<IDataboxRecord> {
       versionHash: manifest.versionHash,
       versionTimestamp: manifest.versionTimestamp,
       paymentAddress: manifest.paymentAddress,
-      giftCardAddress: manifest.giftCardAddress,
+      giftCardIssuerIdentity: manifest.giftCardIssuerIdentity,
       pricePerQuery: manifest.pricePerQuery,
       scriptHash: manifest.scriptHash,
       scriptEntrypoint: manifest.scriptEntrypoint,
@@ -87,7 +87,7 @@ export interface IDataboxRecord {
   versionTimestamp: number;
   pricePerQuery: number;
   paymentAddress: string;
-  giftCardAddress: string;
+  giftCardIssuerIdentity: string;
   schemaInterface: string;
   scriptHash: string;
   scriptEntrypoint: string;

--- a/databox/core/test/DataboxCore.test.ts
+++ b/databox/core/test/DataboxCore.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   await DataboxCore.start();
   packager = new Packager(require.resolve('./databoxes/bootup.ts'));
   dbx = await packager.build();
-});
+}, 30e3);
 
 afterAll(() => {
   rmdirSync(storageDir, { recursive: true });
@@ -66,7 +66,7 @@ test('can get metadata about an uploaded databox', async () => {
     runApi('Databox.meta', { versionHash: packager.manifest.versionHash }),
   ).resolves.toEqual({
     latestVersionHash: packager.manifest.versionHash,
-    giftCardPaymentAddresses: [],
+    giftCardIssuerIdentities: [],
     averageBytesPerQuery: expect.any(Number),
     averageMilliseconds: expect.any(Number),
     averageTotalPricePerQuery: 0,

--- a/databox/core/test/PaymentProcessor.test.ts
+++ b/databox/core/test/PaymentProcessor.test.ts
@@ -15,26 +15,28 @@ const lockSpy = jest.spyOn(sidechainClient, 'lockMicronote');
 const claimSpy = jest.spyOn(sidechainClient, 'claimMicronote');
 
 const payment = {
-  microgons: 1000,
-  sidechainIdentity: sidechainIdentity.bech32,
-  micronoteBatchIdentity: micronoteBatchIdentity.bech32,
-  guaranteeBlockHeight: 0,
-  micronoteSignature: micronoteBatchIdentity.sign(sha3(concatAsBuffer('1', 1000))),
-  isGiftCardBatch: false,
-  micronoteId: '1',
-  batchSlug: '123',
-  blockHeight: 0,
-  micronoteBatchUrl: '',
-  sidechainValidationSignature: sidechainIdentity.sign(sha3(micronoteBatchIdentity.bech32)),
+  micronote: {
+    microgons: 1000,
+    sidechainIdentity: sidechainIdentity.bech32,
+    micronoteBatchIdentity: micronoteBatchIdentity.bech32,
+    guaranteeBlockHeight: 0,
+    micronoteSignature: micronoteBatchIdentity.sign(sha3(concatAsBuffer('1', 1000))),
+    micronoteId: '1',
+    batchSlug: '123',
+    blockHeight: 0,
+    micronoteBatchUrl: '',
+    sidechainValidationSignature: sidechainIdentity.sign(sha3(micronoteBatchIdentity.bech32)),
+  }
 };
 
 test('it should ensure a payment has enough microgons', async () => {
   const processor = new PaymentProcessor(
     {
-      microgons: 100,
-      sidechainIdentity,
-      isGiftCardBatch: false,
-    } as any,
+      micronote: {
+        microgons: 100,
+        sidechainIdentity: sidechainIdentity.bech32,
+      } as any
+    },
     {
       anticipatedBytesPerQuery: 100,
       approvedSidechainRootIdentities: new Set([sidechainIdentity.bech32]),

--- a/databox/interfaces/IDataboxCoreConfigureOptions.ts
+++ b/databox/interfaces/IDataboxCoreConfigureOptions.ts
@@ -7,7 +7,8 @@ export default interface IDataboxCoreConfigureOptions {
   databoxesTmpDir: string;
   waitForDataboxCompletionOnShutdown: boolean;
   paymentAddress: string;
-  giftCardAddress: string;
+  giftCardsAllowed: boolean;
+  giftCardsRequiredIssuerIdentity: string;
   enableRunWithLocalPath: boolean;
   uploaderIdentities: string[];
   defaultBytesForPaymentEstimates: number;

--- a/end-to-end/gift-cards/dataUser.ts
+++ b/end-to-end/gift-cards/dataUser.ts
@@ -1,8 +1,5 @@
 import DataboxApiClient from '@ulixee/databox/lib/DataboxApiClient';
-import * as Path from 'path';
 import SidechainClient from '@ulixee/sidechain';
-import Address from '@ulixee/crypto/lib/Address';
-import Identity from '@ulixee/crypto/lib/Identity';
 import { execAndLog } from '../utils';
 
 export default async function main(
@@ -10,32 +7,18 @@ export default async function main(
   databox: {
     databoxHost: string;
     databoxHash: string;
-    claimGiftCard: string;
+    storeGiftCardCommand: string;
   },
   rootDir: string,
 ): Promise<void> {
-  const { databoxHash, databoxHost, claimGiftCard } = databox;
-  // CREATE IDENTITIES
-  const addressPath = Path.resolve(`${__dirname}/addresses/DataboxDevGiftCard.json`);
-  const identityPath = Path.resolve(`${__dirname}/identities/DataboxDev.json`);
+  const { databoxHash, databoxHost, storeGiftCardCommand } = databox;
 
-  execAndLog(`npx @ulixee/crypto identity -f "${identityPath}"`, { stdio: 'inherit' });
-  execAndLog(`npx @ulixee/crypto address U "${addressPath}"`);
-
-  execAndLog(`${claimGiftCard} -h ${sidechainHost}`, {
-    stdio: 'inherit',
+  execAndLog(`${storeGiftCardCommand} -h ${sidechainHost}`, {
     cwd: rootDir,
-    env: {
-      ...process.env,
-      ULX_ADDRESS: addressPath,
-    },
+    stdio: 'inherit',
   });
 
-  // TODO: use stream once available
-  const sidechainClient = new SidechainClient(sidechainHost, {
-    address: Address.readFromPath(addressPath),
-    identity: Identity.loadFromFile(identityPath),
-  });
+  const sidechainClient = new SidechainClient(sidechainHost, {});
   const databoxClient = new DataboxApiClient(databoxHost);
   const databoxMeta = await databoxClient.getMeta(databoxHash);
   const payment = await sidechainClient.createMicroPayment(databoxMeta);
@@ -44,11 +27,7 @@ export default async function main(
   console.log('Result of databox query is:', result);
 
   execAndLog(`npx @ulixee/sidechain gift-card balances -h ${sidechainHost}`, {
-    stdio: 'inherit',
     cwd: rootDir,
-    env: {
-      ...process.env,
-      ULX_ADDRESS: addressPath,
-    },
+    stdio: 'inherit',
   });
 }

--- a/end-to-end/gift-cards/index.ts
+++ b/end-to-end/gift-cards/index.ts
@@ -24,9 +24,6 @@ async function main(): Promise<void> {
     shell: true,
     stdio: 'inherit',
     cwd: sidechainRoot,
-    env: {
-      ...process.env,
-    },
   });
 
   console.log('Starting Sidechain', sidechainRoot);

--- a/end-to-end/utils.ts
+++ b/end-to-end/utils.ts
@@ -1,9 +1,4 @@
-import {
-  ChildProcess, execSync,
-  ExecSyncOptions,
-  ExecSyncOptionsWithBufferEncoding,
-  ExecSyncOptionsWithStringEncoding,
-} from 'child_process';
+import { ChildProcess, execSync, ExecSyncOptions } from 'child_process';
 
 export function getMinerHost(minerProcess: ChildProcess): Promise<string> {
   return new Promise<string>(resolve => {
@@ -18,10 +13,9 @@ export function getMinerHost(minerProcess: ChildProcess): Promise<string> {
   });
 }
 
-export function execAndLog(command: string): Buffer;
-export function execAndLog(command: string, options: ExecSyncOptionsWithStringEncoding): string;
-export function execAndLog(command: string, options: ExecSyncOptionsWithBufferEncoding): Buffer;
-export function execAndLog(command: string, options?: ExecSyncOptions): string | Buffer {
+export function execAndLog(command: string, options?: ExecSyncOptions): string {
   console.log(`--------\n\n\n${command}\n\n\n-------`);
-  return execSync(command, options);
+  options ??= {};
+  options.encoding ??= 'utf8';
+  return execSync(command, options) as string;
 }

--- a/miner/main/env.ts
+++ b/miner/main/env.ts
@@ -1,5 +1,6 @@
 import { loadEnv, parseEnvBool } from '@ulixee/commons/lib/envUtils';
 
+loadEnv(process.cwd());
 loadEnv(__dirname);
 const env = process.env;
 


### PR DESCRIPTION
NOTE: tests won't run without the @ulixee/payments PR being pulled into main first

This PR converts Databox to use the simplified gift cards scheme. It also adds cli commands to:
- `@ulixee/databox gift-cards create -m 100c -d ./databox.js` create a gift card for the existing databox. This process looks up "gift card issuers" installed on the local machine and puts it into a local manifest file for the databox (or uses the existing issuer).
- `@ulixee/databox gift-cards list-issuers` should locally installed "issuer identities". Basically the signing proof that this is a real gift card
- `@ulixee/databox gift-cards create-issuer` create a new issuer for a gift card (stores in <Cache>/ulixee/gift-card-issuers

This PR also makes it so a miner does not have to do anything to participate in gift cards. There are two options:
1.  `giftCardsAllowed` Set to `false` to disable any gift card usage. It's true by default, but a miner might choose to explicitly turn it off.
2. `giftCardsRequiredIssuerIdentity`: An additional security feature requiring a gift card to be signed by both the miner AND the databox in order for the miner to accept it. This would be used if a miner wanted to limit the amount of gift cards a databox author gave out