### PR TITLE
feat(datastore): cli to clone datastores

### DIFF
--- a/datastore/client/cli/cloneDatastore.ts
+++ b/datastore/client/cli/cloneDatastore.ts
@@ -1,0 +1,90 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as ts from 'typescript';
+import { writeFileSync } from 'fs';
+import * as Path from 'path';
+import jsonToSchemaCode from '@ulixee/schema/lib/jsonToSchemaCode';
+import DatastoreApiClient from '../lib/DatastoreApiClient';
+
+export default async function cloneDatastore(
+  url: string,
+  path: string,
+  options: { emitModules: boolean } = { emitModules: false },
+): Promise<void> {
+  const parsedUrl = new URL(url);
+  const datastoreApiClient = new DatastoreApiClient(parsedUrl.host);
+  const meta = await datastoreApiClient.getMeta(parsedUrl.pathname.slice(1));
+  path = Path.resolve(path);
+
+  const schemas: Record<string, string> = {};
+  const passthroughFunctions = Object.entries(meta.functionsByName).map(([x, func]) => {
+    let schemaLine = '';
+    if (func.schemaJson) {
+      schemas[`${x}Schema`] = func.schemaJson;
+      schemaLine = `\n  schema: ${x}Schema,\n`;
+    }
+    return `${x}: new PassthroughFunction({
+  remoteFunction: 'source.${x}',${schemaLine}
+})`;
+  });
+
+  const schemaImports = new Set<string>();
+  const schemaVars = Object.entries(schemas).map(([name, json]) => {
+    const schema = JSON.parse(json);
+    let js = `var ${name} = {\n`;
+
+    if (schema.input) {
+      js += `  input: ${jsonToSchemaCode(schema.input, schemaImports)}\n,`;
+    }
+    if (schema.output) {
+      js += `  output: ${jsonToSchemaCode(schema.output, schemaImports)}`;
+    }
+    return `${js}};\n`;
+  });
+
+  const script = `
+  import { Datastore, PassthroughFunction } from '@ulixee/datastore';
+  import schemaFromJson from '@ulixee/schema/lib/schemaFromJson';
+  import { ${[...schemaImports].join(', ')} } from '@ulixee/schema';
+  
+  const datastore = new Datastore({
+    remoteDatastores: {
+      source: "${url}"
+    },
+    functions: {
+      ${passthroughFunctions}
+    }
+  });
+
+  //////////// SCHEMA DEFINITIONS //////////////////
+  ${schemaVars.join('\n')}
+
+  export default datastore;`;
+
+  const sourceFile = ts.createSourceFile(
+    path,
+    script,
+    ts.ScriptTarget.ES2020,
+    false,
+    ts.ScriptKind.TS,
+  );
+
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed, noEmitHelpers: true });
+  const tsFile = printer.printFile(sourceFile);
+
+  if (path.endsWith('.ts')) {
+    writeFileSync(path, tsFile);
+  } else {
+    const jsFile = ts.transpileModule(tsFile, {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: options.emitModules ? ts.ModuleKind.ES2022 : ts.ModuleKind.CommonJS,
+        esModuleInterop: false,
+        noImplicitUseStrict: true,
+        strict: false,
+        lib: ['es2022'],
+      },
+    });
+    console.log(jsFile);
+    writeFileSync(path, jsFile.outputText);
+  }
+}

--- a/datastore/client/cli/index.ts
+++ b/datastore/client/cli/index.ts
@@ -3,6 +3,7 @@ import type * as CliCommands from '@ulixee/datastore-packager/lib/cliCommands';
 import UlixeeHostsConfig from '@ulixee/commons/config/hosts';
 import DatastoreApiClient from '../lib/DatastoreApiClient';
 import giftCardCommands from './giftCardCommands';
+import cloneDatastore from './cloneDatastore';
 
 const { version } = require('../package.json');
 
@@ -34,6 +35,15 @@ export default function datastoreCommands(): Command {
       'Clear out any version history for this script entrypoint',
     )
     .default(false);
+
+  cli
+    .command('clone')
+    .description('Clone and add onto a Datastore.')
+    .argument('<url>', 'The url of the Datastore.')
+    .argument('<path>', 'The path to output your cloned Datastore.')
+    .action(async (url, path) => {
+      await cloneDatastore(url, path);
+    });
 
   cli
     .command('deploy')

--- a/datastore/client/lib/DatastoreApiClient.ts
+++ b/datastore/client/lib/DatastoreApiClient.ts
@@ -1,5 +1,8 @@
 import { ConnectionToCore, WsTransportToCore } from '@ulixee/net';
-import DatastoreApiSchemas, { IDatastoreApis, IDatastoreApiTypes } from '@ulixee/specification/datastore';
+import DatastoreApiSchemas, {
+  IDatastoreApis,
+  IDatastoreApiTypes,
+} from '@ulixee/specification/datastore';
 import { sha3 } from '@ulixee/commons/lib/hashUtils';
 import { concatAsBuffer } from '@ulixee/commons/lib/bufferUtils';
 import Identity from '@ulixee/crypto/lib/Identity';
@@ -25,6 +28,9 @@ export default class DatastoreApiClient {
   protected activeIterableByStreamId = new Map<string, ResultIterable<any, any>>();
 
   constructor(host: string) {
+    if (host.startsWith('ulx://')) {
+      host = `ws://${host.slice('ulx://'.length)}`;
+    }
     const transport = new WsTransportToCore(`${host}/datastore`);
     this.connectionToCore = new ConnectionToCore(transport);
     this.connectionToCore.on('event', this.onEvent.bind(this));
@@ -34,7 +40,9 @@ export default class DatastoreApiClient {
     return this.connectionToCore.disconnect();
   }
 
-  public async getMeta(versionHash: string): Promise<IDatastoreApiTypes['Datastore.meta']['result']> {
+  public async getMeta(
+    versionHash: string,
+  ): Promise<IDatastoreApiTypes['Datastore.meta']['result']> {
     return await this.runRemote('Datastore.meta', { versionHash });
   }
 
@@ -227,7 +235,12 @@ export default class DatastoreApiClient {
 
   public static createExecSignatureMessage(payment: IPayment, nonce: string): Buffer {
     return sha3(
-      concatAsBuffer('Datastore.exec', payment?.giftCard?.id, payment?.micronote?.micronoteId, nonce),
+      concatAsBuffer(
+        'Datastore.exec',
+        payment?.giftCard?.id,
+        payment?.micronote?.micronoteId,
+        nonce,
+      ),
     );
   }
 

--- a/datastore/client/package.json
+++ b/datastore/client/package.json
@@ -13,6 +13,7 @@
     "./package.json": "./package.json",
     "./lib/utils/Autorun.mjs": "./lib/utils/Autorun.mjs",
     "./lib/*": "./lib/*.js",
+    "./cli/*": "./cli/*.js",
     "./types/*": "./types/*"
   },
   "dependencies": {

--- a/datastore/core/lib/DatastoreManifest.ts
+++ b/datastore/core/lib/DatastoreManifest.ts
@@ -106,6 +106,7 @@ export default class DatastoreManifest implements IDatastoreManifest {
       this.functionsByName[funcName] = {
         corePlugins: funcMeta.corePlugins ?? {},
         prices: funcMeta.prices ?? [{ perQuery: 0, minimum: 0 }],
+        schemaAsJson: funcMeta.schemaAsJson,
       };
     }
     // allow manifest to override above values

--- a/datastore/core/lib/DatastoresTable.ts
+++ b/datastore/core/lib/DatastoresTable.ts
@@ -39,7 +39,11 @@ export default class DatastoresTable extends SqliteTable<IDatastoreRecord> {
         price.minimum ??= price.perQuery;
         price.addOns ??= { perKb: 0 };
       }
-      functionsByName[name] = { corePlugins: func.corePlugins ?? {}, prices };
+      functionsByName[name] = {
+        corePlugins: func.corePlugins ?? {},
+        prices,
+        schemaAsJson: func.schemaAsJson,
+      };
     }
     this.insertNow([
       manifest.versionHash,
@@ -97,6 +101,7 @@ export interface IDatastoreRecord {
   functionsByName: {
     [name: string]: {
       corePlugins: Record<string, string>;
+      schemaAsJson: any;
       prices: {
         perQuery: number;
         minimum: number;

--- a/datastore/core/test/Crawler.test.ts
+++ b/datastore/core/test/Crawler.test.ts
@@ -16,6 +16,9 @@ beforeAll(async () => {
   if (Fs.existsSync(`${__dirname}/datastores/crawl.dbx`)) {
     Fs.unlinkSync(`${__dirname}/datastores/crawl.dbx`);
   }
+  if (Fs.existsSync(`${__dirname}/datastores/crawl.dbx.build`)) {
+    Fs.rmSync(`${__dirname}/datastores/crawl.dbx.build`, { recursive: true });
+  }
 
   miner = new UlixeeMiner();
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
@@ -60,7 +63,7 @@ test('should be able to ask a crawler for a cached result', async () => {
   await expect(
     client.stream(crawler.manifest.versionHash, 'crawlCall', {
       sessionId: '2',
-      maxTimeInCache: (Date.now() - result1[0].runCrawlerTime.getTime() / 1e3),
+      maxTimeInCache: Date.now() - result1[0].runCrawlerTime.getTime() / 1e3,
     }),
     // should use cached version
   ).resolves.toEqual([{ version: '1', crawler: 'none', sessionId: '1' }]);
@@ -88,7 +91,7 @@ test('should get cached result by serialized input if no schema', async () => {
   await expect(
     client.stream(crawler.manifest.versionHash, 'crawlCall', {
       sessionId: '2', // should not call the crawler
-      maxTimeInCache: (Date.now() - result1[0].runCrawlerTime.getTime() / 1e3),
+      maxTimeInCache: Date.now() - result1[0].runCrawlerTime.getTime() / 1e3,
       // change field order to test
       test2: 'abc',
       test1: true,
@@ -106,7 +109,7 @@ test('should get cached result by serialized input if no schema', async () => {
   await expect(
     client.stream(crawler.manifest.versionHash, 'crawlCall', {
       sessionId: '3',
-      maxTimeInCache: (Date.now() - result1[0].runCrawlerTime.getTime() / 1e3),
+      maxTimeInCache: Date.now() - result1[0].runCrawlerTime.getTime() / 1e3,
       test2: 'somethingElse',
       test1: false,
     }),
@@ -142,7 +145,7 @@ test('should get cached result individual input columns', async () => {
   await expect(
     client.stream(crawler.manifest.versionHash, 'crawlWithSchemaCall', {
       sessionId: '2', // should not call the crawler
-      maxTimeInCache: (Date.now() - result1[0].runCrawlerTime.getTime() / 1e3),
+      maxTimeInCache: Date.now() - result1[0].runCrawlerTime.getTime() / 1e3,
       colBool: true,
       colNum: 1,
     }),
@@ -159,7 +162,7 @@ test('should get cached result individual input columns', async () => {
   await expect(
     client.stream(crawler.manifest.versionHash, 'crawlWithSchemaCall', {
       sessionId: '3',
-      maxTimeInCache: (Date.now() - result1[0].runCrawlerTime.getTime() / 1e3),
+      maxTimeInCache: Date.now() - result1[0].runCrawlerTime.getTime() / 1e3,
       colBool: false,
       colNum: 1,
     }),

--- a/datastore/core/test/Datastore.clone.test.ts
+++ b/datastore/core/test/Datastore.clone.test.ts
@@ -1,0 +1,60 @@
+import * as Fs from 'fs';
+import * as Path from 'path';
+import DatastorePackager from '@ulixee/datastore-packager';
+import UlixeeMiner from '@ulixee/miner';
+import DatastoreApiClient from '@ulixee/datastore/lib/DatastoreApiClient';
+import cloneDatastore from "@ulixee/datastore/cli/cloneDatastore";
+
+const storageDir = Path.resolve(process.env.ULX_DATA_DIR ?? '.', 'Datastore.clone.test');
+
+let miner: UlixeeMiner;
+let client: DatastoreApiClient;
+
+beforeAll(async () => {
+  if (Fs.existsSync(`${__dirname}/datastores/cloneme.dbx`)) {
+    Fs.unlinkSync(`${__dirname}/datastores/cloneme.dbx`);
+  }
+
+  if (Fs.existsSync(`${__dirname}/datastores/cloned.dbx`)) {
+    Fs.unlinkSync(`${__dirname}/datastores/cloned.dbx`);
+  }
+
+  miner = new UlixeeMiner();
+  miner.router.datastoreConfiguration = { datastoresDir: storageDir };
+  await miner.listen();
+  client = new DatastoreApiClient(await miner.address);
+});
+
+afterAll(async () => {
+  await miner.close();
+  if (Fs.existsSync(storageDir)) Fs.rmSync(storageDir, { recursive: true });
+});
+
+test('should be able to clone a datastore', async () => {
+  let versionHash: string;
+  {
+    const packager = new DatastorePackager(`${__dirname}/datastores/cloneme.ts`);
+    await packager.build();
+    await client.upload(await packager.dbx.asBuffer());
+    versionHash = packager.manifest.versionHash;
+  }
+
+  const url = `ulx://${await miner.address}/${versionHash}`;
+  await expect(cloneDatastore(url, `${__dirname}/datastores/cloned.ts`)).resolves.toBeUndefined();
+
+  expect(Fs.existsSync(`${__dirname}/datastores/cloned.ts`)).toBeTruthy();
+  const packager = new DatastorePackager(`${__dirname}/datastores/cloned.ts`);
+  await packager.build();
+  await client.upload(await packager.dbx.asBuffer());
+
+  await expect(
+    client.stream(packager.manifest.versionHash, 'cloneUpstream', {}),
+  ).rejects.toThrowError('input');
+
+  await expect(
+    client.stream(packager.manifest.versionHash, 'cloneUpstream', {
+      field: 'str',
+      nested: { field2: true },
+    }),
+  ).resolves.toEqual([{ success: true }]);
+});

--- a/datastore/core/test/Docpage.test.ts
+++ b/datastore/core/test/Docpage.test.ts
@@ -16,6 +16,10 @@ let client: DatastoreApiClient;
 
 beforeAll(async () => {
   jest.spyOn<any, any>(UlixeeHostsConfig.global, 'save').mockImplementation(() => null);
+
+  if (Fs.existsSync(`${__dirname}/datastores/docpage.dbx.build`)) {
+    Fs.rmSync(`${__dirname}/datastores/docpage.dbx.build`, { recursive: true });
+  }
   const packager = new DatastorePackager(`${__dirname}/datastores/docpage.js`);
   await packager.build();
   dbxFile = await packager.dbx.asBuffer();

--- a/datastore/core/test/datastores/cloneme.ts
+++ b/datastore/core/test/datastores/cloneme.ts
@@ -1,0 +1,26 @@
+import Datastore, { Function } from '@ulixee/datastore';
+import { boolean, object, string } from '@ulixee/schema';
+
+export default new Datastore({
+  functions: {
+    cloneUpstream: new Function({
+      run(ctx) {
+        ctx.Output.emit({ success: true });
+      },
+      schema: {
+        input: {
+          field: string({ minLength: 1, description: 'a field you should use' }),
+          nested: object({
+            fields: {
+              field2: boolean(),
+            },
+            optional: true,
+          }),
+        },
+        output: {
+          success: boolean(),
+        },
+      },
+    }),
+  },
+});

--- a/datastore/packager/index.ts
+++ b/datastore/packager/index.ts
@@ -110,6 +110,7 @@ export default class DatastorePackager {
               addOns: functionMeta.addOnPricing,
             },
           ],
+          schemaAsJson: schema,
         };
 
         // lookup upstream pricing

--- a/datastore/packager/test/Packager.test.ts
+++ b/datastore/packager/test/Packager.test.ts
@@ -4,6 +4,8 @@ import { existsSync } from 'fs';
 import DatastoreManifest from '@ulixee/datastore-core/lib/DatastoreManifest';
 import { encodeBuffer } from '@ulixee/commons/lib/bufferUtils';
 import { sha3 } from '@ulixee/commons/lib/hashUtils';
+import { IDatastoreApiTypes } from '@ulixee/specification/datastore';
+import IDatastoreManifest from '@ulixee/specification/types/IDatastoreManifest';
 import DatastorePackager from '../index';
 import DbxFile from '../lib/DbxFile';
 
@@ -173,7 +175,10 @@ module.exports = new Datastore({ functions: { heroFunction }})`,
 });
 
 test('should be able to change the output directory', async () => {
-  const packager = new DatastorePackager(`${__dirname}/assets/historyTest.js`, `${__dirname}/build`);
+  const packager = new DatastorePackager(
+    `${__dirname}/assets/historyTest.js`,
+    `${__dirname}/build`,
+  );
   workingDirectory = packager.dbx.workingDirectory;
   dbxFile = packager.dbxPath;
 
@@ -189,7 +194,7 @@ test('should be able to package a multi-function Datastore', async () => {
   dbxFile = packager.dbxPath;
   workingDirectory = packager.dbx.workingDirectory;
   const dbx = new DbxFile(dbxFile);
-  expect(packager.manifest.toJSON()).toEqual({
+  expect(packager.manifest.toJSON()).toEqual(<IDatastoreManifest>{
     linkedVersions: [],
     scriptEntrypoint: Path.join(`packager`, `test`, `assets`, `multiFunctionTest.js`),
     scriptHash: expect.any(String),
@@ -217,10 +222,12 @@ test('should be able to package a multi-function Datastore', async () => {
         corePlugins: {
           '@ulixee/datastore-plugins-hero': require('../package.json').version,
         },
+        schemaAsJson: { input: { url: { format: 'url', typeName: 'string' } } },
       },
       funcWithOutput: {
         prices: [{ perQuery: 0, minimum: 0, addOns: undefined }],
         corePlugins: {},
+        schemaAsJson: { output: { title: { typeName: 'string' }, html: { typeName: 'string' } } },
       },
     },
     versionHash: DatastoreManifest.createVersionHash(packager.manifest),


### PR DESCRIPTION
This PR introduces the notion of "cloning" a Datastore. It creates PassthroughFunctions for any tables, and imports the schema as code.