### PR TITLE
Clone Project

### DIFF
--- a/datastore/client/cli/cloned-package.json
+++ b/datastore/client/cli/cloned-package.json
@@ -1,0 +1,21 @@
+{
+  "name": "datastore",
+  "version": "0.0.1",
+  "private": true,
+  "main": "datastore.js",
+  "scripts": {
+    "postinstall": "tsc",
+    "deploy": "@ulixee/datastore deploy ./datastore.ts",
+    "credits:create": "@ulixee/datastore credits create"
+  },
+  "engines": {
+    "node": ">=14.20.0"
+  },
+  "dependencies": {
+    "@ulixee/datastore": "2.0.0-alpha.18"
+  },
+  "devDependencies": {
+    "@ulixee/datastore-packager": "2.0.0-alpha.18",
+    "typescript": "~4.9.4"
+  }
+}

--- a/datastore/client/cli/cloned-tsconfig.json
+++ b/datastore/client/cli/cloned-tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "incremental": true,
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "esModuleInterop": false,
+    "declaration": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["**/tsconfig*.json", "node_modules", "**/node_modules"],
+  "include": ["./*.ts"]
+}

--- a/datastore/client/cli/index.ts
+++ b/datastore/client/cli/index.ts
@@ -40,7 +40,7 @@ export default function datastoreCommands(): Command {
     .command('clone')
     .description('Clone and add onto a Datastore.')
     .argument('<url>', 'The url of the Datastore.')
-    .argument('<path>', 'The path to output your cloned Datastore.')
+    .argument('[path]', 'The directory path to output your cloned Datastore.')
     .action(async (url, path) => {
       await cloneDatastore(url, path);
     });

--- a/datastore/core/lib/DatastoresDb.ts
+++ b/datastore/core/lib/DatastoresDb.ts
@@ -10,11 +10,13 @@ export default class DatastoresDb {
 
   private db: SqliteDatabase;
 
-  constructor(baseDir: string) {
+  constructor(baseDir: string, options?: { enableSqliteWAL: boolean }) {
     if (!Fs.existsSync(baseDir)) Fs.mkdirSync(baseDir, { recursive: true });
     this.db = new Database(`${baseDir}/index.db`);
-    this.db.unsafeMode(false);
-    this.db.pragma('journal_mode = WAL');
+    if (options?.enableSqliteWAL) {
+      this.db.unsafeMode(false);
+      this.db.pragma('journal_mode = WAL');
+    }
 
     this.datastoreStats = new DatastoreStatsTable(this.db);
     this.datastoreVersions = new DatastoreVersionsTable(this.db);

--- a/datastore/core/test/Crawler.test.ts
+++ b/datastore/core/test/Crawler.test.ts
@@ -24,6 +24,8 @@ beforeAll(async () => {
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
   await miner.listen();
   client = new DatastoreApiClient(await miner.address);
+  Helpers.needsClosing.push(miner);
+  Helpers.onClose(() => client.disconnect());
 });
 
 beforeEach(() => {
@@ -34,7 +36,7 @@ afterEach(Helpers.afterEach);
 
 afterAll(async () => {
   await Helpers.afterAll();
-  Fs.rmSync(storageDir, { recursive: true });
+  await Fs.promises.rm(storageDir, { recursive: true }).catch(() => null);
 });
 
 test('should be able to run a crawler', async () => {

--- a/datastore/core/test/Crawler.test.ts
+++ b/datastore/core/test/Crawler.test.ts
@@ -24,8 +24,7 @@ beforeAll(async () => {
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
   await miner.listen();
   client = new DatastoreApiClient(await miner.address);
-  Helpers.needsClosing.push(miner);
-  Helpers.onClose(() => client.disconnect());
+  Helpers.onClose(() => client.disconnect(), true);
 });
 
 beforeEach(() => {
@@ -35,6 +34,7 @@ beforeEach(() => {
 afterEach(Helpers.afterEach);
 
 afterAll(async () => {
+  await miner.close()
   await Helpers.afterAll();
   await Fs.promises.rm(storageDir, { recursive: true }).catch(() => null);
 });

--- a/datastore/core/test/Datastore.clone.test.ts
+++ b/datastore/core/test/Datastore.clone.test.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
   miner = new UlixeeMiner();
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
   await miner.listen();
-  client = new DatastoreApiClient(await miner.address);
+  client = new DatastoreApiClient(await miner.address, true);
 
   const packager = new DatastorePackager(`${__dirname}/datastores/cloneme.ts`);
   await packager.build();
@@ -44,11 +44,11 @@ afterAll(async () => {
 });
 
 test('should be able to clone a datastore', async () => {
-  const url = `ulx://${await miner.address}/${versionHash}`;
-  await expect(cloneDatastore(url, `${__dirname}/datastores/cloned.ts`)).resolves.toBeUndefined();
+  const url = `ulx://${await miner.address}/datastore/${versionHash}`;
+  await expect(cloneDatastore(url, `${__dirname}/datastores/cloned`)).resolves.toBeUndefined();
 
-  expect(Fs.existsSync(`${__dirname}/datastores/cloned.ts`)).toBeTruthy();
-  const packager = new DatastorePackager(`${__dirname}/datastores/cloned.ts`);
+  expect(Fs.existsSync(`${__dirname}/datastores/cloned/datastore.ts`)).toBeTruthy();
+  const packager = new DatastorePackager(`${__dirname}/datastores/cloned/datastore.ts`);
   await packager.build();
   await client.upload(await packager.dbx.asBuffer());
 

--- a/datastore/core/test/DatastorePayments.test.ts
+++ b/datastore/core/test/DatastorePayments.test.ts
@@ -285,12 +285,12 @@ test('should be able to embed Credits in a Datastore', async () => {
   });
 
   await cloneDatastore(
-    `ulx://${await miner.address}/${manifest.versionHash}`,
-    `${__dirname}/datastores/clone-output.js`,
+    `ulx://${await miner.address}/datastore/${manifest.versionHash}`,
+    `${__dirname}/datastores/clone-output`,
     { embedCredits: credits },
   );
   await Fs.writeFileSync(
-    `${__dirname}/datastores/clone-output-manifest.json`,
+    `${__dirname}/datastores/clone-output/datastore-manifest.json`,
     JSON.stringify({
       paymentAddress: encodeBuffer(sha3('payme123'), 'ar'),
       functionsByName: {
@@ -303,7 +303,7 @@ test('should be able to embed Credits in a Datastore', async () => {
   );
 
   {
-    const packager2 = new DatastorePackager(`${__dirname}/datastores/clone-output.js`);
+    const packager2 = new DatastorePackager(`${__dirname}/datastores/clone-output/datastore.ts`);
     const dbx2 = await packager2.build();
     const manifest2 = packager2.manifest;
     await client.upload(await dbx2.asBuffer(), { identity: adminIdentity });

--- a/datastore/core/test/PassthroughFunctions.test.ts
+++ b/datastore/core/test/PassthroughFunctions.test.ts
@@ -94,7 +94,7 @@ beforeAll(async () => {
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
   await miner.listen();
   client = new DatastoreApiClient(await miner.address);
-  Helpers.onClose(() => client.disconnect());
+  Helpers.onClose(() => client.disconnect(), true);
 
   const packager = new DatastorePackager(`${__dirname}/datastores/remoteFunction.js`);
   await packager.build();

--- a/datastore/core/test/PassthroughFunctions.test.ts
+++ b/datastore/core/test/PassthroughFunctions.test.ts
@@ -94,6 +94,7 @@ beforeAll(async () => {
   miner.router.datastoreConfiguration = { datastoresDir: storageDir };
   await miner.listen();
   client = new DatastoreApiClient(await miner.address);
+  Helpers.onClose(() => client.disconnect());
 
   const packager = new DatastorePackager(`${__dirname}/datastores/remoteFunction.js`);
   await packager.build();

--- a/datastore/core/test/datastores/cloneme.ts
+++ b/datastore/core/test/datastores/cloneme.ts
@@ -2,6 +2,7 @@ import Datastore, { Function, Table } from '@ulixee/datastore';
 import { boolean, date, object, string } from '@ulixee/schema';
 
 export default new Datastore({
+  name: 'cloneme',
   functions: {
     cloneUpstream: new Function({
       run(ctx) {

--- a/datastore/packager/index.ts
+++ b/datastore/packager/index.ts
@@ -193,7 +193,7 @@ export default class DatastorePackager {
       );
     }
 
-    const datastoreVersionHash = remoteUrl.pathname.slice(1);
+    const [datastoreVersionHash] = remoteUrl.pathname.match(/dbx1[ac-hj-np-z02-9]{18}/)
     DatastoreManifest.validateVersionHash(datastoreVersionHash);
 
     const remoteMeta = {
@@ -201,7 +201,7 @@ export default class DatastorePackager {
       datastoreVersionHash,
       functionName,
     };
-    const datastoreApiClient = new DatastoreApiClient(remoteUrl.host);
+    const datastoreApiClient = new DatastoreApiClient(remoteUrl.host, this.logToConsole);
     try {
       const upstreamMeta = await datastoreApiClient.getMeta(datastoreVersionHash);
       const remoteFunctionDetails = upstreamMeta.functionsByName[functionName];
@@ -233,7 +233,7 @@ export default class DatastorePackager {
       );
     }
 
-    const datastoreVersionHash = remoteUrl.pathname.slice(1);
+    const [datastoreVersionHash] = remoteUrl.pathname.match(/dbx1[ac-hj-np-z02-9]{18}/)
     DatastoreManifest.validateVersionHash(datastoreVersionHash);
 
     const remoteMeta = {
@@ -241,7 +241,7 @@ export default class DatastorePackager {
       datastoreVersionHash,
       tableName,
     };
-    const datastoreApiClient = new DatastoreApiClient(remoteUrl.host);
+    const datastoreApiClient = new DatastoreApiClient(remoteUrl.host, this.logToConsole);
     try {
       const upstreamMeta = await datastoreApiClient.getMeta(datastoreVersionHash);
       const remoteDetails = upstreamMeta.tablesByName[tableName];

--- a/datastore/packager/package.json
+++ b/datastore/packager/package.json
@@ -22,6 +22,7 @@
     "ws": "^7.4.6"
   },
   "devDependencies": {
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
This PR allows creates a folder and a project when you clone a datastore. It will name the folder the name of the datastore, or just "datastore". It includes typescript and script shortcuts to deploy and create credits.