### PR TITLE
Datastore Context adds crawl, run, fetch and query; Miner startup fix; Autorun multiple functions

### DIFF
--- a/datastore/client/cli/index.ts
+++ b/datastore/client/cli/index.ts
@@ -95,6 +95,7 @@ export default function datastoreCommands(): Command {
     )
     .option('-o, --out-dir <path>', 'A directory path where you want .dbx packages to be saved')
     .option('-u, --upload', 'Upload this package to a Ulixee Miner after packaging.', false)
+    .option('-d, --no-docs', "Don't automatically display the deployed documentation website.", false)
     .addOption(uploadHostOption)
     .addOption(clearVersionHistoryOption)
     .option(
@@ -115,6 +116,7 @@ export default function datastoreCommands(): Command {
         clearVersionHistory,
         identityPath,
         identityPassphrase,
+        noDocs,
       } = options;
       await getPackagerCommands().buildPackage(path, {
         tsconfig,
@@ -125,6 +127,7 @@ export default function datastoreCommands(): Command {
         clearVersionHistory,
         identityPath,
         identityPassphrase,
+        dontAutoshowDocs: noDocs,
       });
     });
 

--- a/datastore/client/index.mjs
+++ b/datastore/client/index.mjs
@@ -29,4 +29,4 @@ export {
 
 export default cjsImport.default;
 
-setupAutorunMjsHack(cjsImport.default);
+setupAutorunMjsHack();

--- a/datastore/client/index.ts
+++ b/datastore/client/index.ts
@@ -14,7 +14,7 @@ import PassthroughFunction from './lib/PassthroughFunction';
 import PassthroughTable from './lib/PassthroughTable';
 import Function from './lib/Function';
 import Crawler from './lib/Crawler';
-import './lib/utils/Autorun';
+import Autorun from './lib/utils/Autorun';
 
 export * as Schema from '@ulixee/schema';
 
@@ -36,5 +36,7 @@ export {
   IFunctionContext,
   IFunctionPlugin,
 };
+
+Autorun.setupAutorunBeforeExitHook(require.main);
 
 export default Datastore;

--- a/datastore/client/interfaces/IDatastoreComponents.ts
+++ b/datastore/client/interfaces/IDatastoreComponents.ts
@@ -4,9 +4,9 @@ import Table from '../lib/Table';
 import CreditsTable from '../lib/CreditsTable';
 
 export default interface IDatastoreComponents<
-  TTable extends TTables<any>,
-  TFunction extends TFunctions<any>,
-  TCrawler extends TCrawlers<any>,
+  TTable extends TTables,
+  TFunction extends TFunctions,
+  TCrawler extends TCrawlers,
 > {
   name?: string;
   description?: string;
@@ -26,19 +26,22 @@ export default interface IDatastoreComponents<
   authenticateIdentity?(identity: string, nonce: string): Promise<boolean> | boolean;
 }
 
-export type TFunctions<T = any> = T extends Function
+export type TFunctions<T = any, TFunc extends Function = Function> = T extends Record<string, TFunc>
   ? {
       [K in keyof T]: T[K];
     }
   : never;
 
-export type TTables<T = any> = T extends Table
+export type TTables<T = any, TTable extends Table = Table> = T extends Record<string, TTable>
   ? {
       [K in keyof T]: T[K];
     }
   : never;
 
-export type TCrawlers<T = any> = T extends Crawler
+export type TCrawlers<T = any, TCrawler extends Crawler = Crawler> = T extends Record<
+  string,
+  TCrawler
+>
   ? {
       [K in keyof T]: T[K];
     }

--- a/datastore/client/interfaces/IFunctionContext.ts
+++ b/datastore/client/interfaces/IFunctionContext.ts
@@ -22,7 +22,7 @@ export default interface IFunctionContext<TSchema extends IFunctionSchema> {
   run<T extends Function>(
     func: T,
     options?: T['runArgsType'],
-  ): Promise<ExtractSchemaType<T['schema']['output']>[]>;
+  ): ResultIterable<ExtractSchemaType<T['schema']['output']>>;
   fetch<T extends Function>(
     func: T,
     options?: T['runArgsType'],

--- a/datastore/client/interfaces/IFunctionContext.ts
+++ b/datastore/client/interfaces/IFunctionContext.ts
@@ -1,6 +1,12 @@
+import { IDatastoreApiTypes } from '@ulixee/specification/datastore';
 import IFunctionSchema, { ExtractSchemaType } from './IFunctionSchema';
 import { IOutputClass } from '../lib/Output';
 import IDatastoreMetadata from './IDatastoreMetadata';
+import Crawler from '../lib/Crawler';
+import Function from '../lib/Function';
+import Table from '../lib/Table';
+import ResultIterable from '../lib/ResultIterable';
+import ICrawlerOutputSchema from './ICrawlerOutputSchema';
 
 export default interface IFunctionContext<TSchema extends IFunctionSchema> {
   input?: ExtractSchemaType<TSchema['input']>;
@@ -10,4 +16,18 @@ export default interface IFunctionContext<TSchema extends IFunctionSchema> {
   datastoreMetadata: IDatastoreMetadata;
   datastoreAffiliateId?: string;
   callerAffiliateId?: string;
+  readonly authentication: IDatastoreApiTypes['Datastore.query']['args']['authentication'];
+  readonly payment: IDatastoreApiTypes['Datastore.query']['args']['payment'];
+  crawl<T extends Crawler>(crawler: T, options?: T['runArgsType']): Promise<ICrawlerOutputSchema>;
+  run<T extends Function>(
+    func: T,
+    options?: T['runArgsType'],
+  ): Promise<ExtractSchemaType<T['schema']['output']>[]>;
+  fetch<T extends Function>(
+    func: T,
+    options?: T['runArgsType'],
+  ): ResultIterable<ExtractSchemaType<T['schema']['output']>>;
+  // TODO: add table options typing
+  fetch<T extends Table>(table: T, options?: any): ResultIterable<ExtractSchemaType<T['schema']>>;
+  query<TResult>(sql: string, boundValues: any[]): Promise<TResult>;
 }

--- a/datastore/client/interfaces/IFunctionExecOptions.ts
+++ b/datastore/client/interfaces/IFunctionExecOptions.ts
@@ -1,11 +1,11 @@
 import { IDatastoreApiTypes } from '@ulixee/specification/datastore';
 import IFunctionSchema, { ExtractSchemaType } from './IFunctionSchema';
 
-export default interface IFunctionExecOptions<ISchema extends IFunctionSchema> {
+export default interface IFunctionExecOptions<ISchema extends IFunctionSchema>
+  extends Pick<
+    IDatastoreApiTypes['Datastore.query']['args'],
+    'payment' | 'affiliateId' | 'authentication'
+  > {
   input?: ExtractSchemaType<ISchema['input']>;
-  output?: ExtractSchemaType<ISchema['output']>;
-  payment?: IDatastoreApiTypes['Datastore.query']['args']['payment'],
-  authentication?: IDatastoreApiTypes['Datastore.query']['args']['authentication'],
   isFromCommandLine?: boolean;
-  affiliateId?: string;
 }

--- a/datastore/client/lib/FunctionContext.ts
+++ b/datastore/client/lib/FunctionContext.ts
@@ -86,13 +86,12 @@ export default class FunctionContext<
     return this.#datastoreInternal.queryInternal(sql, boundValues);
   }
 
-  public async run<T extends Function>(
+  public run<T extends Function>(
     func: T,
     options: T['runArgsType'],
-  ): Promise<ExtractSchemaType<T['schema']['output']>[]> {
+  ): ResultIterable<ExtractSchemaType<T['schema']['output']>> {
     const finalOptions = this.getMergedOptions(options);
-    const result = await func.runInternal(finalOptions);
-    return result as any;
+    return func.runInternal(finalOptions) as any;
   }
 
   private getMergedOptions<T extends IFunctionExecOptions<any>>(options: T): T {

--- a/datastore/client/lib/FunctionContext.ts
+++ b/datastore/client/lib/FunctionContext.ts
@@ -1,9 +1,16 @@
 import { IDatastoreApiTypes } from '@ulixee/specification/datastore';
+import { ExtractSchemaType } from '@ulixee/schema';
 import IFunctionSchema from '../interfaces/IFunctionSchema';
 import FunctionInternal from './FunctionInternal';
 import IFunctionContext from '../interfaces/IFunctionContext';
 import DatastoreInternal from './DatastoreInternal';
 import IDatastoreMetadata from '../interfaces/IDatastoreMetadata';
+import ResultIterable from './ResultIterable';
+import Table from './Table';
+import Function from './Function';
+import Crawler from './Crawler';
+import ICrawlerOutputSchema from '../interfaces/ICrawlerOutputSchema';
+import IFunctionExecOptions from '../interfaces/IFunctionExecOptions';
 
 export default class FunctionContext<
   ISchema extends IFunctionSchema,
@@ -13,6 +20,7 @@ export default class FunctionContext<
   public datastoreMetadata: IDatastoreMetadata;
   public datastoreAffiliateId: string;
   public callerAffiliateId: string;
+  public extraOptions: Record<string, any>;
 
   public get authentication(): IDatastoreApiTypes['Datastore.query']['args']['authentication'] {
     return this.#functionInternal.options.authentication;
@@ -39,14 +47,60 @@ export default class FunctionContext<
   }
 
   #functionInternal: FunctionInternal<ISchema>;
+  #datastoreInternal: DatastoreInternal;
 
-  constructor(
-    functionInternal: FunctionInternal<ISchema>,
-    datastoreInternal: DatastoreInternal,
-  ) {
+  constructor(functionInternal: FunctionInternal<ISchema>, datastoreInternal: DatastoreInternal) {
     this.#functionInternal = functionInternal;
+    const { affiliateId, payment, input, authentication, isFromCommandLine, ...otherOptions } =
+      functionInternal.options;
+    this.extraOptions = otherOptions;
     this.datastoreMetadata = datastoreInternal.metadata;
     this.datastoreAffiliateId = datastoreInternal.affiliateId;
     this.callerAffiliateId = functionInternal.options.affiliateId;
+  }
+
+  public fetch<T extends Function>(
+    func: T,
+    options: T['runArgsType'],
+  ): ResultIterable<ExtractSchemaType<T['schema']['output']>>;
+  public fetch<T extends Table>(
+    table: T,
+    options: any,
+  ): ResultIterable<ExtractSchemaType<T['schema']>>;
+  public fetch(funcOrTable, options): any {
+    const finalOptions = this.getMergedOptions(options);
+    return funcOrTable.runInternal(finalOptions);
+  }
+
+  public async crawl<T extends Crawler>(
+    crawler: T,
+    options: T['runArgsType'] = {},
+  ): Promise<ICrawlerOutputSchema> {
+    const finalOptions = this.getMergedOptions(options);
+    const [crawl] = await crawler.runInternal(finalOptions);
+    return crawl;
+  }
+
+  public query<TResult>(sql: string, boundValues: any[]): Promise<TResult> {
+    // const finalOptions = this.#functionInternal.options;
+    return this.#datastoreInternal.queryInternal(sql, boundValues);
+  }
+
+  public async run<T extends Function>(
+    func: T,
+    options: T['runArgsType'],
+  ): Promise<ExtractSchemaType<T['schema']['output']>[]> {
+    const finalOptions = this.getMergedOptions(options);
+    const result = await func.runInternal(finalOptions);
+    return result as any;
+  }
+
+  private getMergedOptions<T extends IFunctionExecOptions<any>>(options: T): T {
+    const finalOptions = { ...this.#functionInternal.options, ...options };
+    if (options.input) {
+      // merge input
+      finalOptions.input = { ...this.#functionInternal.input, ...options.input };
+    }
+    return finalOptions;
   }
 }

--- a/datastore/client/lib/PassthroughTable.ts
+++ b/datastore/client/lib/PassthroughTable.ts
@@ -43,7 +43,7 @@ export default class PassthroughTable<
     this.remoteSource = source;
   }
 
-  public override async query<T = TRecords[]>(
+  public override async queryInternal<T = TRecords[]>(
     sql: string,
     boundValues: any[] = [],
     options: Omit<

--- a/datastore/client/lib/Table.ts
+++ b/datastore/client/lib/Table.ts
@@ -49,7 +49,7 @@ export default class Table<
     return this.#datastoreInternal;
   }
 
-  public async query<T = TRecords[]>(sql: string, boundValues: any[] = []): Promise<T> {
+  public async queryInternal<T = TRecords[]>(sql: string, boundValues: any[] = []): Promise<T> {
     await this.datastoreInternal.ensureDatabaseExists();
     const name = this.components.name;
     const datastoreInstanceId = this.datastoreInternal.instanceId;

--- a/datastore/client/lib/utils/Autorun.mjs
+++ b/datastore/client/lib/utils/Autorun.mjs
@@ -1,12 +1,10 @@
-import Autorun from './Autorun';
+import Autorun from './Autorun.js';
 
 // this hack allows DatastoreExecutable's beforeExit to know if the mjs script has a default export
 
-export function setupAutorunMjsHack(DatastoreExecutable) {
+export function setupAutorunMjsHack() {
   const module = import(process.argv[1]);
   module.then(x => {
-    if (x.default instanceof DatastoreExecutable) {
-      Autorun.defaultExport = x.default;
-    }
+    Autorun.default.setupAutorunBeforeExitHook({ exports: x });
   });
 }

--- a/datastore/client/test/basic.test.ts
+++ b/datastore/client/test/basic.test.ts
@@ -22,7 +22,7 @@ describe('basic Datastore tests', () => {
       wasRun = true;
     });
 
-    await func.stream({});
+    await func.runInternal({});
     await new Promise(resolve => process.nextTick(resolve));
     expect(await wasRun).toBe(true);
   });

--- a/datastore/client/test/basic.test.ts
+++ b/datastore/client/test/basic.test.ts
@@ -5,12 +5,14 @@ import { Function } from '../index';
 describe('basic Datastore tests', () => {
   it('automatically runs and closes a function', async () => {
     let functionWasRun = false;
-    Autorun.defaultExport = new Function(async ctx => {
-      new ctx.Output({ ran: 'success' });
-      functionWasRun = true;
-    });
+    Autorun.mainModuleExports = {
+      default: new Function(async ctx => {
+        new ctx.Output({ ran: 'success' });
+        functionWasRun = true;
+      }),
+    };
 
-    await Autorun.attemptAutorun(Function);
+    await Autorun.attemptAutorun();
     await new Promise(resolve => process.nextTick(resolve));
     expect(await functionWasRun).toBe(true);
   });

--- a/datastore/client/test/schema.test.ts
+++ b/datastore/client/test/schema.test.ts
@@ -18,7 +18,7 @@ describe('Schemas', () => {
       schema,
     });
 
-    await expect(func.stream({ input: {} as any })).rejects.toThrowError('input did not match');
+    await expect(func.runInternal({ input: {} as any })).rejects.toThrowError('input did not match');
   });
 
   it('will supply defaults to params if not given', async () => {
@@ -46,7 +46,7 @@ describe('Schemas', () => {
       schema,
     });
 
-    await expect(func.stream({ input: { plan: false, for: 1 } } as any)).resolves.toBeTruthy();
+    await expect(func.runInternal({ input: { plan: false, for: 1 } } as any)).resolves.toBeTruthy();
     const input = await runResolver;
     expect(input.date).toBe(moment().add(1, 'days').format('YYYY-MM-DD'));
     expect(input.plan).toBe(false);
@@ -68,7 +68,7 @@ describe('Schemas', () => {
       schema,
     });
 
-    await expect(func.stream({})).rejects.toThrowError('Output did not match');
+    await expect(func.runInternal({})).rejects.toThrowError('Output did not match');
   });
 
   it('will validate output and abort at the first error', async () => {
@@ -99,7 +99,7 @@ describe('Schemas', () => {
       },
     });
 
-    await expect(func.stream({})).rejects.toThrowError('Output did not match');
+    await expect(func.runInternal({})).rejects.toThrowError('Output did not match');
     expect(counter).toBe(2);
   });
 
@@ -120,7 +120,7 @@ describe('Schemas', () => {
       schema,
     });
 
-    await expect(func.stream({ input: { url: 'https://url.com' } })).resolves.toEqual([
+    await expect(func.runInternal({ input: { url: 'https://url.com' } })).resolves.toEqual([
       {
         test: 'good to go',
       },

--- a/datastore/core/bin/datastore-process.ts
+++ b/datastore/core/bin/datastore-process.ts
@@ -47,10 +47,10 @@ process.on('message', async (messageJson: string) => {
         },
       });
     }
-    if (message.action === 'stream') {
+    if (message.action === 'run') {
       const datastore = requireDatastore(message.scriptPath);
 
-      if (!datastore.metadata.functionsByName[message.functionName]) {
+      if (!datastore.functions[message.functionName]) {
         return sendToParent({
           responseId: message.messageId,
           data: new DatastoreNotFoundError(
@@ -59,8 +59,8 @@ process.on('message', async (messageJson: string) => {
         });
       }
 
-      const stream = datastore.stream(message.functionName, message.input);
-      for await (const output of stream) {
+      const iterator = datastore.functions[message.functionName].runInternal(message.functionName, message.input);
+      for await (const output of iterator) {
         sendToParent({
           responseId: null,
           streamId: message.streamId,

--- a/datastore/core/endpoints/Datastore.query.ts
+++ b/datastore/core/endpoints/Datastore.query.ts
@@ -139,7 +139,7 @@ async function runDatastoreFunction<T>(
     if (plugin.beforeExecFunction) await plugin.beforeExecFunction(options);
   }
 
-  return await datastore.functions[functionName].stream(options);
+  return await datastore.functions[functionName].runInternal(options);
 }
 
 async function runDatastorePassthroughQuery<T>(
@@ -153,5 +153,5 @@ async function runDatastorePassthroughQuery<T>(
     payment: request.payment,
     authentication: request.authentication,
   };
-  return await datastore.tables[tableName].query(sql, boundValues, options);
+  return await datastore.tables[tableName].queryInternal(sql, boundValues, options);
 }

--- a/datastore/core/endpoints/Datastore.queryLocalScript.ts
+++ b/datastore/core/endpoints/Datastore.queryLocalScript.ts
@@ -36,7 +36,7 @@ export default new DatastoreApiHandler('Datastore.queryLocalScript', {
       }
 
       outputByFunctionName[functionName] = await context.workTracker.trackRun(
-        datastoreProcess.stream(functionName, input).then(x => x),
+        datastoreProcess.run(functionName, input).then(x => x),
       );
     }
 

--- a/datastore/core/endpoints/Datastore.stream.ts
+++ b/datastore/core/endpoints/Datastore.stream.ts
@@ -44,7 +44,7 @@ export default new DatastoreApiHandler('Datastore.stream', {
           if (plugin.beforeExecFunction) await plugin.beforeExecFunction(options);
         }
 
-        const results = datastore.functions[functionName].stream(options);
+        const results = datastore.functions[functionName].runInternal(options);
         for await (const result of results) {
           context.connectionToClient.sendEvent({
             listenerId: request.streamId,

--- a/datastore/core/index.ts
+++ b/datastore/core/index.ts
@@ -168,36 +168,11 @@ export default class DatastoreCore {
     try {
       this.close = this.close.bind(this);
 
-      if (this.options.serverEnvironment === 'production') {
-        if (!this.options.serverAdminIdentities.length) {
-          const tempIdentity = Identity.createSync();
-          this.options.serverAdminIdentities.push(tempIdentity.bech32);
-          const key = Ed25519.getPrivateKeyBytes(tempIdentity.privateKey);
-          console.warn(`\n
-############################################################################################
-############################################################################################
-###########################  TEMPORARY ADMIN IDENTITY  #####################################
-############################################################################################
-############################################################################################
-
-            A temporary adminIdentity has been installed on your server. 
-
-       To perform admin activities (like issuing Credits for a Datastore), you should 
-                 save and use this Identity from your local system:
-
- npx @ulixee/crypto save-identity --privateKey=${key.toString('base64')}
-
---------------------------------------------------------------------------------------------
-       
-           To dismiss this message, add the following environment variable:
-           
- ULX_SERVER_ADMIN_IDENTITIES=${tempIdentity.bech32},
-
-############################################################################################
-############################################################################################
-############################################################################################
-\n\n`);
-        }
+      if (
+        this.options.serverEnvironment === 'production' &&
+        !this.options.serverAdminIdentities.length
+      ) {
+        this.showTemporaryAdminIdentityPrompt();
       }
 
       if (this.options.enableRunWithLocalPath) {
@@ -283,7 +258,7 @@ export default class DatastoreCore {
   }
 
   private static getApiContext(remoteId?: string): IDatastoreApiContext {
-    if (!this.workTracker) {
+    if (!this.isStarted.isResolved) {
       throw new Error('DatastoreCore has not started');
     }
     return {
@@ -294,5 +269,35 @@ export default class DatastoreCore {
       pluginCoresByName: this.pluginCoresByName,
       sidechainClientManager: this.sidechainClientManager,
     };
+  }
+
+  private static showTemporaryAdminIdentityPrompt(): void {
+    const tempIdentity = Identity.createSync();
+    this.options.serverAdminIdentities.push(tempIdentity.bech32);
+    const key = Ed25519.getPrivateKeyBytes(tempIdentity.privateKey);
+    console.warn(`\n
+############################################################################################
+############################################################################################
+###########################  TEMPORARY ADMIN IDENTITY  #####################################
+############################################################################################
+############################################################################################
+
+            A temporary adminIdentity has been installed on your server. 
+
+       To perform admin activities (like issuing Credits for a Datastore), you should 
+                 save and use this Identity from your local system:
+
+ npx @ulixee/crypto save-identity --privateKey=${key.toString('base64')}
+
+--------------------------------------------------------------------------------------------
+       
+           To dismiss this message, add the following environment variable:
+           
+ ULX_SERVER_ADMIN_IDENTITIES=${tempIdentity.bech32},
+
+############################################################################################
+############################################################################################
+############################################################################################
+\n\n`);
   }
 }

--- a/datastore/core/index.ts
+++ b/datastore/core/index.ts
@@ -17,6 +17,7 @@ import Identity from '@ulixee/crypto/lib/Identity';
 import Ed25519 from '@ulixee/crypto/lib/Ed25519';
 import TypeSerializer from '@ulixee/commons/lib/TypeSerializer';
 import IDatastoreDomainResponse from '@ulixee/datastore/interfaces/IDatastoreDomainResponse';
+import Autorun from '@ulixee/datastore/lib/utils/Autorun';
 import IDatastoreCoreConfigureOptions from './interfaces/IDatastoreCoreConfigureOptions';
 import env from './env';
 import DatastoreRegistry from './lib/DatastoreRegistry';
@@ -188,6 +189,7 @@ export default class DatastoreCore {
       );
       await this.installManuallyUploadedDbxFiles();
 
+      Autorun.isEnabled = false;
       process.env.ULX_DATASTORE_DISABLE_AUTORUN = 'true';
       await new Promise(resolve => process.nextTick(resolve));
 

--- a/datastore/core/interfaces/ILocalDatastoreProcess.ts
+++ b/datastore/core/interfaces/ILocalDatastoreProcess.ts
@@ -8,7 +8,7 @@ export interface IFetchMetaMessage {
 
 export interface IRunMessage {
   messageId: string;
-  action: 'stream';
+  action: 'run';
   functionName: string;
   scriptPath: string;
   input: any;

--- a/datastore/core/lib/LocalDatastoreProcess.ts
+++ b/datastore/core/lib/LocalDatastoreProcess.ts
@@ -39,14 +39,14 @@ export default class LocalDatastoreProcess extends TypedEventEmitter<{ error: Er
     });
   }
 
-  public stream(functionName: string, input: any): ResultIterable<any> {
+  public run(functionName: string, input: any): ResultIterable<any> {
     const iterable = new ResultIterable();
     streamIdCounter += 1;
     const streamId = streamIdCounter;
     this.#streamsById[streamId] = iterable.push.bind(iterable);
     void (async () => {
       const data = await this.sendMessageToChild<IRunMessage, IExecResponseData>({
-        action: 'stream',
+        action: 'run',
         scriptPath: this.scriptPath,
         functionName,
         input,

--- a/datastore/core/test/Datastore.queryInternal.test.ts
+++ b/datastore/core/test/Datastore.queryInternal.test.ts
@@ -22,7 +22,7 @@ afterAll(async () => {
 });
 
 test('query datastore table', async () => {
-  const records = await directDatastore.query('SELECT * FROM testers');
+  const records = await directDatastore.queryInternal('SELECT * FROM testers');
   expect(records).toMatchObject([
     { firstName: 'Caleb', lastName: 'Clark', isTester: true },
     { firstName: 'Blake', lastName: 'Byrnes', isTester: null },
@@ -30,7 +30,7 @@ test('query datastore table', async () => {
 }, 30e3);
 
 test('query datastore function', async () => {
-  const records = await directDatastore.query('SELECT * FROM test(shouldTest => true)');
+  const records = await directDatastore.queryInternal('SELECT * FROM test(shouldTest => true)');
   expect(records).toMatchObject([
     {
       testerEcho: true,
@@ -40,7 +40,7 @@ test('query datastore function', async () => {
 }, 30e3);
 
 test('query specific fields on function', async () => {
-  const records = await directDatastore.query('SELECT greeting FROM test(shouldTest => true)');
+  const records = await directDatastore.queryInternal('SELECT greeting FROM test(shouldTest => true)');
   expect(records).toMatchObject([
     {
       greeting: 'Hello world',
@@ -50,7 +50,7 @@ test('query specific fields on function', async () => {
 
 test('left join table on functions', async () => {
   const sql = `SELECT greeting, firstName FROM test(shouldTest => true) LEFT JOIN testers ON testers.isTester=test.shouldTest`;
-  const records = await directDatastore.query(sql);
+  const records = await directDatastore.queryInternal(sql);
   expect(records).toMatchObject([
     {
       greeting: 'Hello world',

--- a/datastore/core/test/Datastore.queryInternalFunctionResult.test.ts
+++ b/datastore/core/test/Datastore.queryInternalFunctionResult.test.ts
@@ -24,7 +24,7 @@ afterAll(async () => {
 });
 
 test('should be able to query function directly', async () => {
-  const data = await directFunction.query('SELECT * FROM self(tester => true)');
+  const data = await directFunction.queryInternal('SELECT * FROM self(tester => true)');
   expect(data).toMatchObject([
     { testerEcho: true },
   ]);

--- a/datastore/core/test/Datastore.queryInternalTable.test.ts
+++ b/datastore/core/test/Datastore.queryInternalTable.test.ts
@@ -24,10 +24,10 @@ afterAll(async () => {
 });
 
 test('should be able to query table directly', async () => {
-  const data = await directTable.query('SELECT * FROM self');
+  const data = await directTable.queryInternal('SELECT * FROM self');
 
   expect(data).toMatchObject([
-    { title: 'Hello', success: true }, 
-    { title: 'World', success: false } 
+    { title: 'Hello', success: true },
+    { title: 'World', success: false }
   ]);
 });

--- a/datastore/core/test/LocalDatastoreProcess.test.ts
+++ b/datastore/core/test/LocalDatastoreProcess.test.ts
@@ -35,14 +35,14 @@ test('it can extract the datastore schema', async () => {
 test('returns datastore errors', async () => {
   const scriptPath = Path.resolve(__dirname, 'datastores/output.js');
   const datastoreProcess = new LocalDatastoreProcess(scriptPath);
-  await expect(datastoreProcess.stream('default', {})).rejects.toThrowError('not found');
+  await expect(datastoreProcess.run('default', {})).rejects.toThrowError('not found');
   await datastoreProcess.close();
 });
 
 test('it can run the datastore and return output', async () => {
   const scriptPath = Path.resolve(__dirname, 'datastores/output.js');
   const datastoreProcess = new LocalDatastoreProcess(scriptPath);
-  const outputs = await datastoreProcess.stream('putout', {});
+  const outputs = await datastoreProcess.run('putout', {});
   await datastoreProcess.close();
 
   expect(outputs).toEqual([{ success: true }]);
@@ -51,7 +51,7 @@ test('it can run the datastore and return output', async () => {
 test('it can get streamed results as one promise', async () => {
   const scriptPath = Path.resolve(__dirname, 'datastores/stream.js');
   const datastoreProcess = new LocalDatastoreProcess(scriptPath);
-  const outputs = await datastoreProcess.stream('streamer', {});
+  const outputs = await datastoreProcess.run('streamer', {});
   await datastoreProcess.close();
 
   expect(outputs).toEqual([{ record: 0 }, { record: 1 }, { record: 2 }]);
@@ -62,7 +62,7 @@ test('it can  streamed results one at a time', async () => {
   const datastoreProcess = new LocalDatastoreProcess(scriptPath);
   let counter = 0;
   const outputs = [];
-  for await (const record of datastoreProcess.stream('streamer', {})) {
+  for await (const record of datastoreProcess.run('streamer', {})) {
     counter += 1;
     outputs.push(record);
   }

--- a/datastore/core/test/datastores/crawl.ts
+++ b/datastore/core/test/datastores/crawl.ts
@@ -42,12 +42,12 @@ const datastore = new Datastore({
   },
   functions: {
     crawlCall: new Function(async ctx => {
-      const crawl = await datastore.crawl('crawl', ctx.input);
+      const crawl = await ctx.crawl(datastore.crawlers.crawl, ctx.input);
       ctx.Output.emit({ ...crawl, runCrawlerTime });
     }),
     crawlWithSchemaCall: new Function({
       async run(ctx) {
-        const crawl = await datastore.crawl('crawlWithSchema', ctx.input);
+        const crawl = await ctx.crawl(datastore.crawlers.crawlWithSchema, ctx.input);
         ctx.Output.emit({ ...crawl, runCrawlerTime });
       },
       schema: {

--- a/datastore/docs/advanced/hero-plugin.md
+++ b/datastore/docs/advanced/hero-plugin.md
@@ -55,8 +55,8 @@ const datastore = new Datastore({
     ulixee: new Function(async context => {
       const { input, Output, HeroReplay } = context;
       const maxTimeInCache = input.maxTimeInCache || 5 * 60;
-      const crawledContent = await datastore.crawl('ulixee', { maxTimeInCache });
-      const heroReplay = new HeroReplay(crawledContent);
+      const crawler = datastore.crawlers.ulixee;
+      const heroReplay = await HeroReplay.fromCrawler(crawler, { input: { maxTimeInCache } });
       const h1 = await heroReplay.detachedElements.get('h1');
       const output = new Output();
       output.title = h1.textContent;
@@ -79,7 +79,8 @@ The HeroFunctionPlugin for Hero adds "automatically connecting" Hero and Hero Re
 ### run _(functionContext)_ {#run-hero}
 
 - functionContext.Hero `Hero`. [Hero](https://ulixee.org/docs/hero/basic-client/hero) constructor that is automatically connected and cleaned up.
-- functionContext.HeroReplay `HeroReplay`. [HeroReplay](https://ulixee.org/docs/hero/basic-client/hero-replay) constructor that's automatically connected and cleaned up.
+- functionContext.HeroReplay `HeroReplay`. [HeroReplay](https://ulixee.org/docs/hero/basic-client/hero-replay) constructor that's automatically connected and cleaned up. Includes an extra static function `fromCrawler` to create an instance from a [Crawler](../basics/crawler.md) instance.
+  - `static fromCrawler_(crawler, options)_`. Arguments: [crawler](../basics/crawler.md) - a Crawler instance, and options: all options that can be passed to a Function `run` callback. Options will be merged with the calling FunctionContext. Input values provided will be merged with existing input values.
 
 ## Constructor
 

--- a/datastore/docs/advanced/puppeteer-plugin.md
+++ b/datastore/docs/advanced/puppeteer-plugin.md
@@ -52,5 +52,5 @@ const datastore = new Datastore({
     }, PuppeteerFunctionPlugin),
   },
 });
-await datastore.functions.pupp.stream({ waitForInitialPage: false });
+await datastore.functions.pupp.runInternal({ waitForInitialPage: false });
 ```

--- a/datastore/docs/basics/crawler.md
+++ b/datastore/docs/basics/crawler.md
@@ -60,14 +60,4 @@ A Table automatically created to store cached results. The table name is `crawle
 
 ## Methods
 
-### stream _ (options)_ {#stream}
-
-Stream Outputs from the Crawler as they're emitted. The result is an AsyncIterable, so can be used to get each Output record as it is emitted. Alternatively, if you await the result, it will wait for the process to complete and return all Output records as an array. Parameter options are the `input` schema, or any values if none is defined.
-
-#### Return Promise/AsyncIterable of schema['Output'] Returns an AsyncIterable streaming results one at a time, or a Promise waiting for all results. The objects are the defined Schema Output records.
-
-### crawl _ (input)_ {#crawl}
-
-Execute the Crawler and return the resulting metadata. Arguments are the `input` parameters defined in the schema.
-
-#### Return Promise<ICrawlerOutputSchema>. Returns a promise of the Crawler output (version, sessionId and crawler).
+No public methods added from [Function](./function.md).

--- a/datastore/docs/basics/datastore.md
+++ b/datastore/docs/basics/datastore.md
@@ -87,8 +87,6 @@ Object containing [Tables](./table.md) keyed by their name.
 
 Object containing an optional key/value of remoteDatastore "names" to urls of the remoteDatastore used as part of [PassthroughFunctions](./passthrough-function.md). Urls take the format `ulx://<MinerHost>/<DatastoreVersionHash>`.
 
-## Methods
-
 ### authenticateIdentity _(identity, nonce)_ {#authenticateIdentity}
 
 An optional callback that can be used to secure a Datastore. This method can allow you to issue private Identities to remote Datastore consumers and only allow those users to access your Datastore. An Identity can be created using the `@ulixee/crypto` cli:
@@ -128,17 +126,9 @@ export default new Datastore({
 The Datastore Core will automatically ensure that any calling authentication messages include the following properties before passing the identity and nonce to your `authenticateIdentity` callback:
 
 - identity `string`. A bech32 encoded Identity of the caller.
-- signature `Buffer`. A valid Ed25519 signature providing proof of the Identity private key. The signature message is a sha3 of `Datastore.exec` + any `GiftCard Id` + any `Micronote Id` + the included `nonce`.
+- signature `Buffer`. A valid Ed25519 signature providing proof of the Identity private key. The signature message is a sha3 of `Datastore.exec` + any `Credits Id` + any `Micronote Id` + the included `nonce`.
 - nonce `string`. A unique nonce code. This nonce can be used for additional "unique" calls validation if desired.
 
-### crawl _ (crawlerName, input)_ {#crawl}
+## Methods
 
-Execute a crawler and return the resulting crawler metadata. Second parameter is the `input` parameters defined in the schema.
-
-#### Return Promise<ICrawlerOutputSchema>. Returns a promise of the crawler output (version, sessionId and crawler).
-
-### stream _ (functionName, input)_ {#stream}
-
-Execute a function and stream results. Options can include `input` parameters defined in the schema.
-
-#### Return AsyncIterable | Promise<schema['output']>. Returns a promise of the defined schema values, which can be waited for as one result at a time.
+No public methods provided.

--- a/datastore/docs/basics/function-context.md
+++ b/datastore/docs/basics/function-context.md
@@ -6,15 +6,33 @@ The FunctionContext class is passed into the [`run`](./function#constructor) cal
 
 ## Properties
 
-### authentication
+### authentication {#authentication}
 
 An optional object passed to call the function. It's provided here to pass on to remote function calls that might be made from the function.
 
 Authentication includes:
 
 - identity `string`. A bech32 encoded Identity of the caller.
-- signature `Buffer`. An ed25519 signature providing proof of the Identity private key. The signature message is the concatenation of: `Datastore.exec`, any `GiftCard Id`, any `Micronote Id`, and a unique `nonce`
+- signature `Buffer`. An ed25519 signature providing proof of the Identity private key. The signature message is the concatenation of: `Datastore.exec`, any `Credits Id`, any `Micronote Id`, and a unique `nonce`
 - nonce `string`. A unique nonce code. This nonce can be used for additional "unique" calls validation if desired.
+
+### callerAffiliateId
+
+The affiliateId provided (if any) to this Function call.
+
+#### **Returns** `string`.
+
+### datastoreAffiliateId
+
+The affiliateId of the containing Datastore.
+
+#### **Returns** `string`.
+
+### datastoreMetadata
+
+Metadata about all [Functions](./function.md), [Crawlers](./crawler.md) and [Tables](./table.md) installed in this Datastore.
+
+#### **Returns** 'IDatastoreMetadata'
 
 ### input
 
@@ -28,12 +46,18 @@ Output class. Can be constructed into a new Output instance, or can use the stat
 
 #### **Returns** [`Output`](./output.md)
 
+### outputs
+
+List of outputs created during the given run.
+
+#### **Returns** Array of created [`Output`](./output.md) objects.
+
 ### payment
 
 The payment supplied to the Datastore Core for payment. Top level keys are:
 
 - micronote `IMicronote`. A micronote created by a valid Sidechain.
-- giftCard `GiftCard`. A gift card issued by the Datastore author or Core server.
+- credits `{ id, secret }`. A credits object to use, issued by the Datastore.
 
 ### schema
 
@@ -43,4 +67,45 @@ A schema defining inputs and outputs for the function.
 
 ## Methods
 
-No public methods.
+### crawl _(crawler, options)_ {#crawl}
+
+Execute the [`crawler`](./crawler.md) and return the resulting metadata. Arguments are the `input` parameters defined in the schema.
+
+#### **Arguments**:
+
+- crawler [`Crawler`](./crawler.md) The Crawler instance to run.
+- options `object`. Parameters to run the crawler. This parameter will default all values to the context. eg, the payment, authentication and affiliateId of the caller will be defaulted to the values provided to the original function this FunctionContext has been passed into.
+  - payment `IPayment`. Override the payment provided to this context.
+  - authentication [authentication](#authentication). Override the authentication supplied to the calling context.
+  - input [input](#input). Merge values into the calling input. If you are calling a Crawler from a Function, and you supply only a `maxTimeInCache` value, it will be _added_ to the input values provided to the Function.
+  - affiliateId `string`. Override the affiliateId provided to the calling function.
+
+#### Return Promise<ICrawlerOutputSchema>. Returns a promise of the Crawler output (version, sessionId and crawler).
+
+### fetch _(functionOrTable, options)_ {#fetch}
+
+Alias for [`run`](#run). This function executes and returns results for a query.
+
+
+#### Return Promise/AsyncIterable of schema['Output'] Returns an AsyncIterable streaming results one at a time, or a Promise waiting for all results. The objects are the defined Schema Output records.
+
+### query _(sql, boundValues)_ {#query}
+
+Queries the Datastore with the given sql and bound values. Uses PostgresSQL query syntax. Currently supports $1, $2, $3 parameter syntax.
+
+#### Return Promise<TSqlSelect[]> Return a promise of records matching the schema types of the selected columns.  
+
+### run _(function, options)_ {#run}
+
+Execute the passed in function. The result is an AsyncIterable, which can be used to get each Output record as it is emitted. Alternatively, if you await the result, it will wait for the process to complete and return all Output records as an array. Parameter options are the `input` schema, or any values if none is defined.
+
+#### **Arguments**:
+
+- function [`Function`](./function.md) The Function instance to run.
+- options `object`. Parameters to run the crawler. This parameter will default all values to the context. eg, the payment, authentication and affiliateId of the caller will be defaulted to the values provided to the original function this FunctionContext has been passed into.
+    - payment `IPayment`. Override the payment provided to this context.
+    - authentication [authentication](#authentication). Override the authentication supplied to the calling context.
+    - input [input](#input). Merge values into the calling input. If you are calling a Crawler from a Function, and you supply only a `maxTimeInCache` value, it will be _added_ to the input values provided to the Function.
+    - affiliateId `string`. Override the affiliateId provided to the calling function.
+
+#### Return Promise/AsyncIterable of schema['Output'] Returns an AsyncIterable streaming results one at a time, or a Promise waiting for all results. The objects are the defined Schema Output records.

--- a/datastore/docs/basics/function.md
+++ b/datastore/docs/basics/function.md
@@ -61,8 +61,10 @@ The second argument is a list of zero or more plugins.
 
 ## Methods
 
-### stream _ (options)_ {#stream}
+### runInternal _ (options)_ {#stream}
 
-Stream Outputs from the Function as they're emitted. The result is an AsyncIterable, so can be used to get each Output record as it is emitted. Alternatively, if you await the result, it will wait for the process to complete and return all Output records as an array. Parameter options are the `input` schema, or any values if none is defined.
+Run the Function and get the resulting Outputs. The result is an AsyncIterable, so can be used to get each Output record as it is emitted. Alternatively, if you await the result, it will wait for the process to complete and return all Output records as an array. Parameter options are the `input` schema, or any values if none is defined.
+
+NOTE: this function is labeled "internal" because no context will be supplied to function from the calling context. If, for instance, you call this Function from inside another Function, you will lose payment, authentication, affiliateId, etc unless you explicitly provide them.
 
 #### Return Promise/AsyncIterable of schema['Output'] Returns an AsyncIterable streaming results one at a time, or a Promise waiting for all results. The objects are the defined Schema Output records.

--- a/datastore/docs/basics/output.md
+++ b/datastore/docs/basics/output.md
@@ -11,17 +11,17 @@ import { Function, HeroFunctionPlugin } from '@ulixee/datastore-plugins-hero';
 
 const func = new Function(async ctx => {
   const { Output, Hero } = ctx;
-
+  
   const links = [
     { name: 'Google', href: 'https://www.google.com' },
     { name: 'Hacker News', href: 'https://news.ycombinator.com' },
   ];
-
+  
   const hero = new Hero();
-
+  
   for (const page of links) {
     await hero.goto(page.href);
-
+    
     for (const link of await hero.querySelectorAll('a')) {
       const output = new Output({
         // will be added to the output array
@@ -35,7 +35,7 @@ const func = new Function(async ctx => {
 
 (async () => {
   // Records can be consumed as they are emitted
-  for await (const output of func.stream()) {
+  for await (const output of func.runInternal()) {
     console.log(output, new Date());
   }
 })();

--- a/datastore/docs/basics/passthrough-table.md
+++ b/datastore/docs/basics/passthrough-table.md
@@ -48,7 +48,7 @@ const datastore = new Datastore({
 });
 
 // will print records from `users` table `[{ firstName: 'John', lastName: 'Doe' }]`
-datastore.tables.table2.query(`select * from self`).then(console.log);
+datastore.tables.table2.queryInternal(`select * from self`).then(console.log);
 ```
 
 ## Constructor

--- a/datastore/docs/basics/table.md
+++ b/datastore/docs/basics/table.md
@@ -39,9 +39,9 @@ Components contains the following properties.
 
 ## Methods
 
-### query _ (sql, boundValues)_ {#query}
+### queryInternal _ (sql, boundValues)_ {#query}
 
-A table has a built-in query method. This method can be used without attaching a Table to any Datastore if you wish to test it out. Your table name can optionally be `self` in this method.
+Internal method to query the table. This method can be used without attaching a Table to any Datastore if you wish to test it out. Your table name can optionally be `self` in this method.
 
 #### **Arguments**:
 

--- a/datastore/docs/basics/table.md
+++ b/datastore/docs/basics/table.md
@@ -17,7 +17,7 @@ const table = new Table({
 });
 
 // will log { title: 'Hello', success: true }
-table.query(`select * from self where success=$1`, [true]).then(console.log);
+table.queryInternal(`select * from self where success=$1`, [true]).then(console.log);
 ```
 
 ## Constructor

--- a/datastore/docs/overview/deployment.md
+++ b/datastore/docs/overview/deployment.md
@@ -88,7 +88,6 @@ When you package a Datastore, a Manifest is created with the following propertie
     - addOns `object`. Optional price add-ons. Currently only `perKb` is supported.
     - remoteMeta `object`. Optional information about the remote Datastore Function being invoked (if applicable). 
 - paymentAddress `string`. Optional address to use with the Ulixee Sidechain for payments.
-- giftCardIssuerIdentity `string`. Optional Gift Card issuer identity used to create GiftCards on the Ulixee Sidechain.
 
 ### Setting values:
 

--- a/datastore/examples/basic.mjs
+++ b/datastore/examples/basic.mjs
@@ -1,6 +1,6 @@
 // NOTE: you must start your own Ulixee Server to run this example.
-
-import { Function, HeroFunctionPlugin } from '@ulixee/datastore-for-hero';
+import * as HeroPlugin from  '@ulixee/datastore-plugins-hero';
+import { Function, HeroFunctionPlugin } from '@ulixee/datastore-plugins-hero';
 
 export default new Function(datastore => {
   console.log('INPUT: ', datastore.input);

--- a/datastore/examples/extractElements.ts
+++ b/datastore/examples/extractElements.ts
@@ -29,11 +29,11 @@ const datastore = new Datastore({
   },
   functions: {
     extract: new Function(async ({ HeroReplay, Output }) => {
-      const lastRun = await datastore.crawl('crawl', {
-        url: 'https://ulixee.org',
+      const heroReplay = await HeroReplay.fromCrawler(crawl, {
+        input: {
+          url: 'https://ulixee.org',
+        },
       });
-
-      const heroReplay = new HeroReplay(lastRun);
       const h1 = await heroReplay.detachedElements.get('h1');
       // NOTE: synchronous APIs. No longer running in browser.
       const output = new Output();

--- a/datastore/examples/extractResources.ts
+++ b/datastore/examples/extractResources.ts
@@ -1,7 +1,6 @@
 // NOTE: you must start your own Ulixee Miner to run this example.
 
 import { Crawler, Datastore, Function, HeroFunctionPlugin } from '@ulixee/datastore-plugins-hero';
-import * as moment from 'moment';
 
 const datastore = new Datastore({
   crawlers: {
@@ -16,9 +15,9 @@ const datastore = new Datastore({
   },
   functions: {
     extract: new Function(async ({ HeroReplay, Output }) => {
-      const lastRun = await datastore.crawl('crawl', { maxTimeInCache: 24 * 60 * 60 });
-
-      const heroReplay = new HeroReplay(lastRun);
+      const heroReplay = await HeroReplay.fromCrawler(datastore.crawlers.crawl, {
+        input: { maxTimeInCache: 24 * 60 * 60 },
+      });
       const { detachedResources } = heroReplay;
       const xhrs = await detachedResources.getAll('xhr');
 

--- a/datastore/examples/extractStorage.ts
+++ b/datastore/examples/extractStorage.ts
@@ -22,9 +22,10 @@ const datastore = new Datastore({
   },
   functions: {
     extract: new Function(async ({ HeroReplay, Output }) => {
-      const lastRun = await datastore.crawl('crawl', { maxTimeInCache: 24 * 60 * 60 });
+      const heroReplay = await HeroReplay.fromCrawler(datastore.crawlers.crawl, {
+        input: { maxTimeInCache: 24 * 60 * 60 },
+      });
 
-      const heroReplay = new HeroReplay(lastRun);
       const localStorage = await heroReplay.getSnippet('localStorage');
       const sessionStorage = await heroReplay.getSnippet('sessionStorage');
       const cookies = await heroReplay.getSnippet('cookies');

--- a/datastore/examples/news.ycombinator.com-extract.ts
+++ b/datastore/examples/news.ycombinator.com-extract.ts
@@ -1,7 +1,6 @@
 // NOTE: you must start your own Ulixee Miner to run this example.
 
 import { Crawler, Datastore, Function, HeroFunctionPlugin } from '@ulixee/datastore-plugins-hero';
-import { dateSubtract } from '@ulixee/schema';
 
 const datastore = new Datastore({
   crawlers: {
@@ -31,10 +30,11 @@ const datastore = new Datastore({
   },
   functions: {
     hackernews: new Function(async ({ Output, HeroReplay }) => {
-      const lastCrawl = await datastore.crawl('hackernews', {
-        maxTimeInCache: 24 * 60 * 60,
+      const { detachedElements } = await HeroReplay.fromCrawler(datastore.crawlers.hackernews, {
+        input: {
+          maxTimeInCache: 24 * 60 * 60,
+        },
       });
-      const { detachedElements } = new HeroReplay(lastCrawl);
       const storyElement = await detachedElements.get('table');
       const stories = storyElement.querySelectorAll('.athing');
       for (const story of stories) {

--- a/datastore/examples/news.ycombinator.com-items.ts
+++ b/datastore/examples/news.ycombinator.com-items.ts
@@ -36,10 +36,11 @@ const datastore = new Datastore({
   },
   functions: {
     news: new Function(async ({ Output, HeroReplay }) => {
-      const lastCrawl = await datastore.crawl('news', {
-        maxTimeInCache: 24 * 60 * 60,
+      const heroReplay = await HeroReplay.fromCrawler(datastore.crawlers.news, {
+        input: {
+          maxTimeInCache: 24 * 60 * 60,
+        },
       });
-      const heroReplay = new HeroReplay(lastCrawl);
       const titles = await heroReplay.detachedElements.getAll('titles');
       const subtitles = await heroReplay.detachedElements.getAll('subtitles');
       for (let i = 0; i < titles.length; i += 1) {

--- a/datastore/plugins/hero-client/index.mjs
+++ b/datastore/plugins/hero-client/index.mjs
@@ -21,6 +21,4 @@ export {
   Schema,
 };
 
-export default cjsImport.default;
-
-setupAutorunMjsHack(cjsImport.default);
+setupAutorunMjsHack();

--- a/datastore/plugins/hero-client/test/basic.test.ts
+++ b/datastore/plugins/hero-client/test/basic.test.ts
@@ -42,9 +42,9 @@ describe('basic Datastore tests', () => {
         await new context.Hero();
         resolve(true);
       }, HeroFunctionPlugin);
-      Autorun.defaultExport = func;
+      Autorun.mainModuleExports = { func };
     });
-    await Autorun.attemptAutorun(Function);
+    await Autorun.attemptAutorun();
     await new Promise(resolve => process.nextTick(resolve));
     expect(await ranScript).toBe(true);
 
@@ -67,7 +67,7 @@ describe('basic Datastore tests', () => {
     }, HeroFunctionPlugin);
     datastoreFunction.disableAutorun = true;
     expect(connection.outgoingSpy.mock.calls).toHaveLength(0);
-    await datastoreFunction.stream({});
+    await datastoreFunction.runInternal({});
     const outgoingHeroCommands = connection.outgoingSpy.mock.calls;
     expect(outgoingHeroCommands.map(c => c[0].command)).toMatchObject([
       'Core.connect',
@@ -86,7 +86,7 @@ describe('basic Datastore tests', () => {
       await hero.goto('https://news.ycombinator.org');
     }, HeroFunctionPlugin);
     datastoreFunction.disableAutorun = true;
-    await datastoreFunction.stream({});
+    await datastoreFunction.runInternal({});
 
     const outgoingHeroCommands = connection.outgoingSpy.mock.calls;
     expect(outgoingHeroCommands.map(c => c[0].command)).toContain('Session.close');
@@ -105,7 +105,7 @@ describe('basic Datastore tests', () => {
     }, HeroFunctionPlugin);
     datastoreFunction.disableAutorun = true;
 
-    await expect(datastoreFunction.stream({})).rejects.toThrowError();
+    await expect(datastoreFunction.runInternal({})).rejects.toThrowError();
 
     const outgoingHeroCommands = connection.outgoingSpy.mock.calls;
     expect(outgoingHeroCommands.map(c => c[0].command)).toContain('Session.close');

--- a/datastore/plugins/hero-client/test/output.test.ts
+++ b/datastore/plugins/hero-client/test/output.test.ts
@@ -38,7 +38,7 @@ describe('basic output tests', () => {
       output.test = true;
       const hero = new ctx.Hero();
       await hero.sessionId;
-    }, HeroFunctionPlugin).stream({});
+    }, HeroFunctionPlugin).runInternal({});
 
     const outgoingCommands = connection.outgoingSpy.mock.calls;
     expect(outgoingCommands.map(c => c[0].command)).toMatchObject([
@@ -98,7 +98,7 @@ describe('basic output tests', () => {
       },
       HeroFunctionPlugin,
     );
-    await func.stream({ connectionToCore });
+    await func.runInternal({ connectionToCore });
 
     const sessionId = await sessionIdPromise;
     const db = new SessionDb(sessionId, { readonly: true });
@@ -154,7 +154,7 @@ describe('basic output tests', () => {
 
       sessionIdPromise.resolve(sessionId);
     }, HeroFunctionPlugin);
-    await func.stream({ connectionToCore });
+    await func.runInternal({ connectionToCore });
 
     const sessionId = await sessionIdPromise;
 

--- a/datastore/plugins/puppeteer-client/index.mjs
+++ b/datastore/plugins/puppeteer-client/index.mjs
@@ -3,22 +3,22 @@ import cjsImport from './index.js';
 
 const {
   PuppeteerFunctionPlugin,
+  Observable,
+  Datastore,
   Function,
   Crawler,
   PassthroughFunction,
-  Observable,
   Schema,
 } = cjsImport;
 
 export {
   PuppeteerFunctionPlugin,
+  Observable,
+  Datastore,
   Function,
   Crawler,
   PassthroughFunction,
-  Observable,
   Schema,
 };
 
-export default cjsImport.default;
-
-setupAutorunMjsHack(cjsImport.default);
+setupAutorunMjsHack();

--- a/datastore/plugins/puppeteer-client/test/basic.test.ts
+++ b/datastore/plugins/puppeteer-client/test/basic.test.ts
@@ -1,22 +1,9 @@
 import { Helpers } from '@ulixee/datastore-testing';
-import Autorun from '@ulixee/datastore/lib/utils/Autorun';
 import { Function, PuppeteerFunctionPlugin } from '../index';
 
 afterAll(Helpers.afterAll);
 
 describe('basic puppeteerFunction tests', () => {
-  it('automatically runs and closes a function', async () => {
-    const ranScript = new Promise(resolve => {
-      Autorun.defaultExport = new Function(async ctx => {
-        resolve(true);
-      }, PuppeteerFunctionPlugin);
-    });
-    Autorun.defaultExport.disableAutorun = false;
-    await Autorun.attemptAutorun(Function);
-    await new Promise(resolve => process.nextTick(resolve));
-    expect(await ranScript).toBe(true);
-  });
-
   it('waits until run method is explicitly called', async () => {
     let hasCompleted = false;
     const puppeteerFunction = new Function(async ctx => {
@@ -27,7 +14,7 @@ describe('basic puppeteerFunction tests', () => {
       hasCompleted = true;
     }, PuppeteerFunctionPlugin);
     puppeteerFunction.disableAutorun = true;
-    await puppeteerFunction.stream({});
+    await puppeteerFunction.runInternal({});
     expect(hasCompleted).toBe(true);
   }, 30e3);
 
@@ -40,7 +27,7 @@ describe('basic puppeteerFunction tests', () => {
       await page.goto('https://example.org');
     }, PuppeteerFunctionPlugin);
     puppeteerFunction.disableAutorun = true;
-    await puppeteerFunction.stream({});
+    await puppeteerFunction.runInternal({});
     expect(closeSpy).toBeCalledTimes(1);
   });
 
@@ -56,7 +43,7 @@ describe('basic puppeteerFunction tests', () => {
     }, PuppeteerFunctionPlugin);
     puppeteerFunction.disableAutorun = true;
 
-    await expect(puppeteerFunction.stream({})).rejects.toThrowError('testy');
+    await expect(puppeteerFunction.runInternal({})).rejects.toThrowError('testy');
     expect(closeSpy).toBeCalledTimes(1);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "datastore/docpage/src",
     "**/website",
     "**/docs",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "**/*.mjs"
   ]
 }

--- a/website/src/pages/data-tools/datastore/Example.vue
+++ b/website/src/pages/data-tools/datastore/Example.vue
@@ -11,15 +11,16 @@
       </p>
 
       <Prism language="shell">
-        npm install @ulixee/datastore-for-hero
+        npm install @ulixee/datastore-plugins-hero
       </Prism>
 
       <h2 class="font-bold mt-8">Create Your First Datastore</h2>
       <p>The following script is exactly the same as the <router-link to="/hero/example">Hero Example</router-link>  except this one is wrapped in a Datastore. </p>
       <Prism language="javascript">
-        import DatastoreForHero from '@ulixee/datastore-for-hero';
+        import { Function, HeroFunctionPlugin } from '@ulixee/datastore-plugins-hero';
 
-        export new DatastoreForHero(async { hero, output } => {
+        export new Function(async { Hero, Output } => {
+          const hero = new Hero();
           await hero.goto('https://ulixee.org/tryit/welcome-to-hero');
 
           output.title = await hero.querySelector('.title').innerText;
@@ -30,8 +31,8 @@
             assert(hero.querySelector('.loading').getAttribute('data-pct'), 100);
           });
 
-          output.description = await hero.querySelector('.description');
-        });
+          Output.emit({ description: await hero.querySelector('.description') });
+        }, HeroFunctionPlugin);
       </Prism>
 
       <p>You can run above code directly from the command line by using `node example-datastore.js`, but the real power


### PR DESCRIPTION
This PR adds a few items:
1. Makes the default functions on Datastore marked as internal (internalQuery, internalRun, etc). Then it adds crawl/run/fetch/query to the run context. This allows us to pass through the authentication, payment, etc from the caller.
2. HeroReplay adds a static fromCrawler when passed into a context. This allows you to request a crawler instance by using HeroReplay.fromCrawler(crawlerInstance)
3. Autorun now allows a function name/export to be specified and will run a function if it matches, or is the only option in the entry point 
4. Fixes an issue starting the miner that was waiting for the wrong variable to be initialized. Also fixes a timing issue starting.