### PR TITLE
feat(datastore): http api for credits balance

### DIFF
--- a/datastore/core/test/Docpage.test.ts
+++ b/datastore/core/test/Docpage.test.ts
@@ -7,6 +7,8 @@ import DatastoreApiClient from '@ulixee/datastore/lib/DatastoreApiClient';
 import UlixeeHostsConfig from '@ulixee/commons/config/hosts';
 import IDatastoreManifest from '@ulixee/specification/types/IDatastoreManifest';
 import * as Hostile from 'hostile';
+import axios from 'axios';
+import Identity from '@ulixee/crypto/lib/Identity';
 
 const storageDir = Path.resolve(process.env.ULX_DATA_DIR ?? '.', 'Datastore.docpage.test');
 
@@ -14,6 +16,7 @@ let dbxFile: Buffer;
 let miner: UlixeeMiner;
 let manifest: IDatastoreManifest;
 let client: DatastoreApiClient;
+const adminIdentity = Identity.createSync();
 
 beforeAll(async () => {
   jest.spyOn<any, any>(UlixeeHostsConfig.global, 'save').mockImplementation(() => null);
@@ -27,15 +30,18 @@ beforeAll(async () => {
   dbxFile = await packager.dbx.asBuffer();
   manifest = packager.manifest.toJSON();
   miner = new UlixeeMiner();
-  miner.router.datastoreConfiguration = { datastoresDir: storageDir };
+  miner.router.datastoreConfiguration = {
+    datastoresDir: storageDir,
+    serverAdminIdentities: [adminIdentity.bech32],
+  };
   await miner.listen();
   client = new DatastoreApiClient(await miner.address);
-  await client.upload(dbxFile);
+  await client.upload(dbxFile, { identity: adminIdentity });
 });
 
 afterAll(async () => {
   await miner?.close();
-  if (process.env.CI !== 'true')  Hostile.remove('127.0.0.1', 'docs.datastoresrus.com');
+  if (process.env.CI !== 'true') Hostile.remove('127.0.0.1', 'docs.datastoresrus.com');
   if (Fs.existsSync(storageDir)) {
     if (Fs.existsSync(storageDir)) Fs.rmSync(storageDir, { recursive: true });
   }
@@ -51,6 +57,37 @@ test('should be able to access documentation through a datastore domain', async 
   const port = await miner.port;
   const res = await Axios.get(`http://docs.datastoresRus.com:${port}`);
   expect(res.data.includes('Docpage - Ulixee Datastore')).toBe(true);
+});
+
+test('should be able to use a domain to get a credit balance', async () => {
+  const port = await miner.port;
+  const credits = await client.createCredits(manifest.versionHash, 1002, adminIdentity);
+  await expect(
+    axios
+      .get(`http://docs.datastoresRus.com:${port}/free-credits?${credits.id}:${credits.secret}`, {
+        responseType: 'json',
+        headers: { accept: 'application/json' },
+      })
+      .then(x => x.data),
+  ).resolves.toEqual({
+    balance: 1002,
+    issuedCredits: 1002,
+  });
+
+  // can also use the full address
+  await expect(
+    axios
+      .get(
+        `http://${await miner.address}/datastore/${manifest.versionHash}/free-credits?${
+          credits.id
+        }:${credits.secret}`,
+        { responseType: 'json', headers: { accept: 'application/json' } },
+      )
+      .then(x => x.data),
+  ).resolves.toEqual({
+    balance: 1002,
+    issuedCredits: 1002,
+  });
 });
 
 test('should be able to parse domain urls', async () => {

--- a/miner/main/lib/CoreRouter.ts
+++ b/miner/main/lib/CoreRouter.ts
@@ -43,6 +43,7 @@ export default class CoreRouter {
     [key: string]: IHttpHandleFn;
   } = {
     datastore: DatastoreCore.routeHttp.bind(DatastoreCore),
+    datastoreCreditBalance: DatastoreCore.routeCreditsBalanceApi.bind(DatastoreCore),
     datastoreRoot: DatastoreCore.routeHttpRoot.bind(DatastoreCore),
     datastoreOptions: DatastoreCore.routeOptions.bind(DatastoreCore),
   };
@@ -52,10 +53,11 @@ export default class CoreRouter {
 
     miner.addWsRoute('/hero', this.handleSocketRequest.bind(this, 'hero'));
     miner.addWsRoute('/datastore', this.handleSocketRequest.bind(this, 'datastore'));
+    miner.addHttpRoute('/server-details', 'GET', this.handleHttpServerDetails.bind(this));
+    miner.addHttpRoute(/.*\/free-credits\/?\?crd[A-Za-z0-9_]{8}.*/, 'GET', this.handleHttpRequest.bind(this, 'datastoreCreditBalance'));
     miner.addHttpRoute(/\/datastore\/(.+)/, 'GET', this.handleHttpRequest.bind(this, 'datastore'));
     miner.addHttpRoute(/\/(.*)/, 'GET', this.handleHttpRequest.bind(this, 'datastoreRoot'));
     miner.addHttpRoute('/', 'OPTIONS', this.handleHttpRequest.bind(this, 'datastoreOptions'));
-    miner.addHttpRoute('/server-details', 'GET', this.handleHttpServerDetails.bind(this));
 
     for (const module of CoreRouter.datastorePluginsToRegister) {
       safeRegisterModule(module);


### PR DESCRIPTION
Api is the same url as the free-credits url (with domain or without), but you must provided an http header of accept: application/json.